### PR TITLE
Remove assembly dependency ( this fixes #5 )

### DIFF
--- a/.paket/Paket.Restore.targets
+++ b/.paket/Paket.Restore.targets
@@ -1,0 +1,276 @@
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <!-- Prevent dotnet template engine to parse this file -->
+  <!--/-:cnd:noEmit-->
+  <PropertyGroup>
+    <!-- make MSBuild track this file for incremental builds. -->
+    <!-- ref https://blogs.msdn.microsoft.com/msbuild/2005/09/26/how-to-ensure-changes-to-a-custom-target-file-prompt-a-rebuild/ -->
+    <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
+    <!-- Mark that this target file has been loaded.  -->
+    <IsPaketRestoreTargetsFileLoaded>true</IsPaketRestoreTargetsFileLoaded>
+    <PaketToolsPath>$(MSBuildThisFileDirectory)</PaketToolsPath>
+    <PaketRootPath>$(MSBuildThisFileDirectory)..\</PaketRootPath>
+    <PaketRestoreCacheFile>$(PaketRootPath)paket-files\paket.restore.cached</PaketRestoreCacheFile>
+    <PaketLockFilePath>$(PaketRootPath)paket.lock</PaketLockFilePath>
+    <MonoPath Condition="'$(MonoPath)' == '' And Exists('/Library/Frameworks/Mono.framework/Commands/mono')">/Library/Frameworks/Mono.framework/Commands/mono</MonoPath>
+    <MonoPath Condition="'$(MonoPath)' == ''">mono</MonoPath>
+    <!-- Paket command -->
+    <PaketExePath Condition=" '$(PaketExePath)' == '' AND Exists('$(PaketRootPath)paket.exe')">$(PaketRootPath)paket.exe</PaketExePath>
+    <PaketExePath Condition=" '$(PaketExePath)' == '' ">$(PaketToolsPath)paket.exe</PaketExePath>
+    <PaketCommand Condition=" '$(OS)' == 'Windows_NT'">"$(PaketExePath)"</PaketCommand>
+    <PaketCommand Condition=" '$(OS)' != 'Windows_NT' ">$(MonoPath) --runtime=v4.0.30319 "$(PaketExePath)"</PaketCommand>
+
+    <!-- .net core fdd -->
+    <_PaketExeExtension>$([System.IO.Path]::GetExtension("$(PaketExePath)"))</_PaketExeExtension>
+    <PaketCommand Condition=" '$(_PaketExeExtension)' == '.dll' ">dotnet "$(PaketExePath)"</PaketCommand>
+
+    <!-- no extension is a shell script -->
+    <PaketCommand Condition=" '$(_PaketExeExtension)' == '' ">"$(PaketExePath)"</PaketCommand>
+
+    <PaketBootStrapperExePath Condition=" '$(PaketBootStrapperExePath)' == '' AND Exists('$(PaketRootPath)paket.bootstrapper.exe')">$(PaketRootPath)paket.bootstrapper.exe</PaketBootStrapperExePath>
+    <PaketBootStrapperExePath Condition=" '$(PaketBootStrapperExePath)' == '' ">$(PaketToolsPath)paket.bootstrapper.exe</PaketBootStrapperExePath>
+    <PaketBootStrapperCommand Condition=" '$(OS)' == 'Windows_NT'">"$(PaketBootStrapperExePath)"</PaketBootStrapperCommand>
+    <PaketBootStrapperCommand Condition=" '$(OS)' != 'Windows_NT' ">$(MonoPath) --runtime=v4.0.30319 "$(PaketBootStrapperExePath)"</PaketBootStrapperCommand>
+
+    <!-- Disable automagic references for F# dotnet sdk -->
+    <!-- This will not do anything for other project types -->
+    <!-- see https://github.com/fsharp/fslang-design/blob/master/RFCs/FS-1032-fsharp-in-dotnet-sdk.md -->
+    <DisableImplicitFSharpCoreReference>true</DisableImplicitFSharpCoreReference>
+    <DisableImplicitSystemValueTupleReference>true</DisableImplicitSystemValueTupleReference>
+  </PropertyGroup>
+
+  <Target Name="PaketRestore" Condition="'$(PaketRestoreDisabled)' != 'True'" BeforeTargets="_GenerateDotnetCliToolReferenceSpecs;_GenerateProjectRestoreGraphPerFramework;_GenerateRestoreGraphWalkPerFramework;CollectPackageReferences" >
+
+    <!-- Step 1 Check if lockfile is properly restored -->
+    <PropertyGroup>
+      <PaketRestoreRequired>true</PaketRestoreRequired>
+      <NoWarn>$(NoWarn);NU1603</NoWarn>
+    </PropertyGroup>
+
+    <!-- Because ReadAllText is slow on osx/linux, try to find shasum and awk -->
+    <PropertyGroup>
+        <PaketRestoreCachedHasher Condition="'$(OS)' != 'Windows_NT' And '$(PaketRestoreCachedHasher)' == '' And Exists('/usr/bin/shasum') And Exists('/usr/bin/awk')">/usr/bin/shasum $(PaketRestoreCacheFile) | /usr/bin/awk '{ print $1 }'</PaketRestoreCachedHasher>
+        <PaketRestoreLockFileHasher Condition="'$(OS)' != 'Windows_NT' And '$(PaketRestoreLockFileHash)' == '' And Exists('/usr/bin/shasum') And Exists('/usr/bin/awk')">/usr/bin/shasum $(PaketLockFilePath) | /usr/bin/awk '{ print $1 }'</PaketRestoreLockFileHasher>
+    </PropertyGroup>
+
+    <!-- If shasum and awk exist get the hashes -->
+    <Exec Condition=" '$(PaketRestoreCachedHasher)' != '' " Command="$(PaketRestoreCachedHasher)" ConsoleToMSBuild='true'>
+        <Output TaskParameter="ConsoleOutput" PropertyName="PaketRestoreCachedHash" />
+    </Exec>
+    <Exec Condition=" '$(PaketRestoreLockFileHasher)' != '' " Command="$(PaketRestoreLockFileHasher)" ConsoleToMSBuild='true'>
+        <Output TaskParameter="ConsoleOutput" PropertyName="PaketRestoreLockFileHash" />
+    </Exec>
+
+    <PropertyGroup Condition="Exists('$(PaketRestoreCacheFile)') ">
+      <!-- if no hash has been done yet fall back to just reading in the files and comparing them -->
+      <PaketRestoreCachedHash Condition=" '$(PaketRestoreCachedHash)' == '' ">$([System.IO.File]::ReadAllText('$(PaketRestoreCacheFile)'))</PaketRestoreCachedHash>
+      <PaketRestoreLockFileHash Condition=" '$(PaketRestoreLockFileHash)' == '' ">$([System.IO.File]::ReadAllText('$(PaketLockFilePath)'))</PaketRestoreLockFileHash>
+      <PaketRestoreRequired>true</PaketRestoreRequired>
+      <PaketRestoreRequired Condition=" '$(PaketRestoreLockFileHash)' == '$(PaketRestoreCachedHash)' ">false</PaketRestoreRequired>
+      <PaketRestoreRequired Condition=" '$(PaketRestoreLockFileHash)' == '' ">true</PaketRestoreRequired>
+    </PropertyGroup>
+
+    <!-- Do a global restore if required -->
+    <Exec Command='$(PaketBootStrapperCommand)' Condition="Exists('$(PaketBootStrapperExePath)') AND !(Exists('$(PaketExePath)'))" ContinueOnError="false" />
+    <Exec Command='$(PaketCommand) restore' Condition=" '$(PaketRestoreRequired)' == 'true' " ContinueOnError="false" />
+
+    <!-- Step 2 Detect project specific changes -->
+    <PropertyGroup>
+      <PaketReferencesCachedFilePath>$(MSBuildProjectDirectory)\obj\$(MSBuildProjectFile).paket.references.cached</PaketReferencesCachedFilePath>
+      <!-- MyProject.fsproj.paket.references has the highest precedence -->
+      <PaketOriginalReferencesFilePath>$(MSBuildProjectFullPath).paket.references</PaketOriginalReferencesFilePath>
+      <!-- MyProject.paket.references -->
+      <PaketOriginalReferencesFilePath Condition=" !Exists('$(PaketOriginalReferencesFilePath)')">$(MSBuildProjectDirectory)\$(MSBuildProjectName).paket.references</PaketOriginalReferencesFilePath>
+      <!-- paket.references -->
+      <PaketOriginalReferencesFilePath Condition=" !Exists('$(PaketOriginalReferencesFilePath)')">$(MSBuildProjectDirectory)\paket.references</PaketOriginalReferencesFilePath>
+      <PaketResolvedFilePath>$(MSBuildProjectDirectory)\obj\$(MSBuildProjectFile).$(TargetFramework).paket.resolved</PaketResolvedFilePath>
+      <PaketRestoreRequired>true</PaketRestoreRequired>
+      <PaketRestoreRequiredReason>references-file-or-cache-not-found</PaketRestoreRequiredReason>
+    </PropertyGroup>
+
+    <!-- Step 2 a Detect changes in references file -->
+    <PropertyGroup Condition="Exists('$(PaketOriginalReferencesFilePath)') AND Exists('$(PaketReferencesCachedFilePath)') ">
+      <PaketRestoreCachedHash>$([System.IO.File]::ReadAllText('$(PaketReferencesCachedFilePath)'))</PaketRestoreCachedHash>
+      <PaketRestoreReferencesFileHash>$([System.IO.File]::ReadAllText('$(PaketOriginalReferencesFilePath)'))</PaketRestoreReferencesFileHash>
+      <PaketRestoreRequiredReason>references-file</PaketRestoreRequiredReason>
+      <PaketRestoreRequired Condition=" '$(PaketRestoreReferencesFileHash)' == '$(PaketRestoreCachedHash)' ">false</PaketRestoreRequired>
+    </PropertyGroup>
+
+    <PropertyGroup Condition="!Exists('$(PaketOriginalReferencesFilePath)') AND !Exists('$(PaketReferencesCachedFilePath)') ">
+      <!-- If both don't exist there is nothing to do. -->
+      <PaketRestoreRequired>false</PaketRestoreRequired>
+    </PropertyGroup>
+
+    <!-- Step 2 b detect relevant changes in project file (new targetframework) -->
+    <PropertyGroup Condition=" !Exists('$(PaketResolvedFilePath)') AND '$(TargetFramework)' != '' ">
+      <PaketRestoreRequired>true</PaketRestoreRequired>
+      <PaketRestoreRequiredReason>target-framework '$(TargetFramework)'</PaketRestoreRequiredReason>
+    </PropertyGroup>
+
+    <!-- Step 3 Restore project specific stuff if required -->
+    <Message Condition=" '$(PaketRestoreRequired)' == 'true' " Importance="low" Text="Detected a change ('$(PaketRestoreRequiredReason)') in the project file '$(MSBuildProjectFullPath)', calling paket restore" />
+    <Exec Command='$(PaketCommand) restore --project "$(MSBuildProjectFullPath)"' Condition=" '$(PaketRestoreRequired)' == 'true' " ContinueOnError="false" />
+
+    <!-- This shouldn't actually happen, but just to be sure. -->
+    <Error Condition=" !Exists('$(PaketResolvedFilePath)') AND '$(TargetFramework)' != '' AND '$(ResolveNuGetPackages)' != 'False' " Text="Paket file '$(PaketResolvedFilePath)' is missing while restoring $(MSBuildProjectFile). Please delete 'paket-files/paket.restore.cached' and call 'paket restore'." />
+
+    <!-- Step 4 forward all msbuild properties (PackageReference, DotNetCliToolReference) to msbuild -->
+    <ReadLinesFromFile Condition="Exists('$(PaketResolvedFilePath)')" File="$(PaketResolvedFilePath)" >
+      <Output TaskParameter="Lines" ItemName="PaketReferencesFileLines"/>
+    </ReadLinesFromFile>
+
+    <ItemGroup Condition=" Exists('$(PaketResolvedFilePath)') AND '@(PaketReferencesFileLines)' != '' " >
+      <PaketReferencesFileLinesInfo Include="@(PaketReferencesFileLines)" >
+        <PackageName>$([System.String]::Copy('%(PaketReferencesFileLines.Identity)').Split(',')[0])</PackageName>
+        <PackageVersion>$([System.String]::Copy('%(PaketReferencesFileLines.Identity)').Split(',')[1])</PackageVersion>
+        <AllPrivateAssets>$([System.String]::Copy('%(PaketReferencesFileLines.Identity)').Split(',')[4])</AllPrivateAssets>
+      </PaketReferencesFileLinesInfo>
+      <PackageReference Include="%(PaketReferencesFileLinesInfo.PackageName)">
+        <Version>%(PaketReferencesFileLinesInfo.PackageVersion)</Version>
+        <PrivateAssets Condition="%(PaketReferencesFileLinesInfo.AllPrivateAssets) == 'true'">All</PrivateAssets>
+      </PackageReference>
+    </ItemGroup>
+
+    <PropertyGroup>
+      <PaketCliToolFilePath>$(MSBuildProjectDirectory)/obj/$(MSBuildProjectFile).paket.clitools</PaketCliToolFilePath>
+    </PropertyGroup>
+
+    <ReadLinesFromFile File="$(PaketCliToolFilePath)" >
+      <Output TaskParameter="Lines" ItemName="PaketCliToolFileLines"/>
+    </ReadLinesFromFile>
+
+    <ItemGroup Condition=" '@(PaketCliToolFileLines)' != '' " >
+      <PaketCliToolFileLinesInfo Include="@(PaketCliToolFileLines)" >
+        <PackageName>$([System.String]::Copy('%(PaketCliToolFileLines.Identity)').Split(',')[0])</PackageName>
+        <PackageVersion>$([System.String]::Copy('%(PaketCliToolFileLines.Identity)').Split(',')[1])</PackageVersion>
+      </PaketCliToolFileLinesInfo>
+      <DotNetCliToolReference Include="%(PaketCliToolFileLinesInfo.PackageName)">
+        <Version>%(PaketCliToolFileLinesInfo.PackageVersion)</Version>
+      </DotNetCliToolReference>
+    </ItemGroup>
+
+    <!-- Disabled for now until we know what to do with runtime deps - https://github.com/fsprojects/Paket/issues/2964
+    <PropertyGroup>
+      <RestoreConfigFile>$(MSBuildProjectDirectory)/obj/$(MSBuildProjectFile).NuGet.Config</RestoreConfigFile>
+    </PropertyGroup> -->
+
+  </Target>
+
+  <Target Name="PaketDisableDirectPack" AfterTargets="_IntermediatePack" BeforeTargets="GenerateNuspec" Condition="('$(IsPackable)' == '' Or '$(IsPackable)' == 'true') And Exists('$(MSBuildProjectDirectory)/obj/$(MSBuildProjectFile).references')" >
+    <PropertyGroup>
+      <ContinuePackingAfterGeneratingNuspec>false</ContinuePackingAfterGeneratingNuspec>
+    </PropertyGroup>
+  </Target>
+
+  <Target Name="PaketOverrideNuspec" AfterTargets="GenerateNuspec" Condition="('$(IsPackable)' == '' Or '$(IsPackable)' == 'true') And Exists('$(MSBuildProjectDirectory)/obj/$(MSBuildProjectFile).references')" >
+    <ItemGroup>
+      <_NuspecFilesNewLocation Include="$(BaseIntermediateOutputPath)$(Configuration)\*.nuspec"/>
+    </ItemGroup>
+
+    <PropertyGroup>
+      <PaketProjectFile>$(MSBuildProjectDirectory)/$(MSBuildProjectFile)</PaketProjectFile>
+      <ContinuePackingAfterGeneratingNuspec>true</ContinuePackingAfterGeneratingNuspec>
+      <UseNewPack>false</UseNewPack>
+      <UseNewPack Condition=" '$(NuGetToolVersion)' != '4.0.0' ">true</UseNewPack>
+      <AdjustedNuspecOutputPath>$(BaseIntermediateOutputPath)$(Configuration)</AdjustedNuspecOutputPath>
+      <AdjustedNuspecOutputPath Condition="@(_NuspecFilesNewLocation) == ''">$(BaseIntermediateOutputPath)</AdjustedNuspecOutputPath>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <_NuspecFiles Include="$(AdjustedNuspecOutputPath)\*.nuspec"/>
+    </ItemGroup>
+
+    <Exec Command='$(PaketCommand) fix-nuspecs files "@(_NuspecFiles)" project-file "$(PaketProjectFile)" ' Condition="@(_NuspecFiles) != ''" />
+
+    <ConvertToAbsolutePath Condition="@(_NuspecFiles) != ''" Paths="@(_NuspecFiles)">
+      <Output TaskParameter="AbsolutePaths" PropertyName="NuspecFileAbsolutePath" />
+    </ConvertToAbsolutePath>      
+        
+
+    <!-- Call Pack -->
+    <PackTask Condition="$(UseNewPack)"
+              PackItem="$(PackProjectInputFile)"
+              PackageFiles="@(_PackageFiles)"
+              PackageFilesToExclude="@(_PackageFilesToExclude)"
+              PackageVersion="$(PackageVersion)"
+              PackageId="$(PackageId)"
+              Title="$(Title)"
+              Authors="$(Authors)"
+              Description="$(Description)"
+              Copyright="$(Copyright)"
+              RequireLicenseAcceptance="$(PackageRequireLicenseAcceptance)"
+              LicenseUrl="$(PackageLicenseUrl)"
+              ProjectUrl="$(PackageProjectUrl)"
+              IconUrl="$(PackageIconUrl)"
+              ReleaseNotes="$(PackageReleaseNotes)"
+              Tags="$(PackageTags)"
+              DevelopmentDependency="$(DevelopmentDependency)"
+              BuildOutputInPackage="@(_BuildOutputInPackage)"
+              TargetPathsToSymbols="@(_TargetPathsToSymbols)"
+              TargetFrameworks="@(_TargetFrameworks)"
+              AssemblyName="$(AssemblyName)"
+              PackageOutputPath="$(PackageOutputAbsolutePath)"
+              IncludeSymbols="$(IncludeSymbols)"
+              IncludeSource="$(IncludeSource)"
+              PackageTypes="$(PackageType)"
+              IsTool="$(IsTool)"
+              RepositoryUrl="$(RepositoryUrl)"
+              RepositoryType="$(RepositoryType)"
+              SourceFiles="@(_SourceFiles->Distinct())"
+              NoPackageAnalysis="$(NoPackageAnalysis)"
+              MinClientVersion="$(MinClientVersion)"
+              Serviceable="$(Serviceable)"
+              FrameworkAssemblyReferences="@(_FrameworkAssemblyReferences)"
+              ContinuePackingAfterGeneratingNuspec="$(ContinuePackingAfterGeneratingNuspec)"
+              NuspecOutputPath="$(AdjustedNuspecOutputPath)"
+              IncludeBuildOutput="$(IncludeBuildOutput)"
+              BuildOutputFolder="$(BuildOutputTargetFolder)"
+              ContentTargetFolders="$(ContentTargetFolders)"
+              RestoreOutputPath="$(RestoreOutputAbsolutePath)"
+              NuspecFile="$(NuspecFileAbsolutePath)"
+              NuspecBasePath="$(NuspecBasePath)"
+              NuspecProperties="$(NuspecProperties)"/>
+
+    <PackTask Condition="! $(UseNewPack)"
+              PackItem="$(PackProjectInputFile)"
+              PackageFiles="@(_PackageFiles)"
+              PackageFilesToExclude="@(_PackageFilesToExclude)"
+              PackageVersion="$(PackageVersion)"
+              PackageId="$(PackageId)"
+              Title="$(Title)"
+              Authors="$(Authors)"
+              Description="$(Description)"
+              Copyright="$(Copyright)"
+              RequireLicenseAcceptance="$(PackageRequireLicenseAcceptance)"
+              LicenseUrl="$(PackageLicenseUrl)"
+              ProjectUrl="$(PackageProjectUrl)"
+              IconUrl="$(PackageIconUrl)"
+              ReleaseNotes="$(PackageReleaseNotes)"
+              Tags="$(PackageTags)"
+              TargetPathsToAssemblies="@(_TargetPathsToAssemblies->'%(FinalOutputPath)')"
+              TargetPathsToSymbols="@(_TargetPathsToSymbols)"
+              TargetFrameworks="@(_TargetFrameworks)"
+              AssemblyName="$(AssemblyName)"
+              PackageOutputPath="$(PackageOutputAbsolutePath)"
+              IncludeSymbols="$(IncludeSymbols)"
+              IncludeSource="$(IncludeSource)"
+              PackageTypes="$(PackageType)"
+              IsTool="$(IsTool)"
+              RepositoryUrl="$(RepositoryUrl)"
+              RepositoryType="$(RepositoryType)"
+              SourceFiles="@(_SourceFiles->Distinct())"
+              NoPackageAnalysis="$(NoPackageAnalysis)"
+              MinClientVersion="$(MinClientVersion)"
+              Serviceable="$(Serviceable)"
+              AssemblyReferences="@(_References)"
+              ContinuePackingAfterGeneratingNuspec="$(ContinuePackingAfterGeneratingNuspec)"
+              NuspecOutputPath="$(AdjustedNuspecOutputPath)"
+              IncludeBuildOutput="$(IncludeBuildOutput)"
+              BuildOutputFolder="$(BuildOutputTargetFolder)"
+              ContentTargetFolders="$(ContentTargetFolders)"
+              RestoreOutputPath="$(RestoreOutputAbsolutePath)"
+              NuspecFile="$(NuspecFileAbsolutePath)"
+              NuspecBasePath="$(NuspecBasePath)"
+              NuspecProperties="$(NuspecProperties)"/>
+  </Target>
+  <!--/+:cnd:noEmit-->
+</Project>

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,6 @@ language: csharp
 sudo: false  # use the new container-based Travis infrastructure 
 
 script:
-  - sh ./build.sh
+  - sh ./build.sh RunTests
 
 

--- a/build.fsx
+++ b/build.fsx
@@ -190,12 +190,8 @@ Target "Build" (fun _ ->
 // Run the unit tests using test runner
 
 Target "RunTests" (fun _ ->
-    !! testAssemblies
-    |> NUnit (fun p ->
-        { p with
-            DisableShadowCopy = true
-            TimeOut = TimeSpan.FromMinutes 20.
-            OutputFile = "TestResults.xml" })
+    Shell.Exec ("tests/SynVer.Tests/bin/"+configuration+"/SyntacticVersioning.Tests.exe","--summary")
+    |> fun r -> if r<>0 then failwith "SyntacticVersioning.Tests.exe failed"
 )
 
 #if MONO
@@ -378,7 +374,7 @@ Target "ReleaseDocs" (fun _ ->
     Git.Commit.Commit tempDocsDir (sprintf "Update generated documentation for version %s" release.NugetVersion)
     Branches.push tempDocsDir
 )
-
+#if !MONO
 #load "paket-files/build/fsharp/FAKE/modules/Octokit/Octokit.fsx"
 open Octokit
 
@@ -411,6 +407,9 @@ Target "Release" (fun _ ->
     |> releaseDraft
     |> Async.RunSynchronously
 )
+#else
+Target "Release" DoNothing
+#endif
 
 Target "BuildPackage" DoNothing
 

--- a/paket.dependencies
+++ b/paket.dependencies
@@ -7,6 +7,9 @@ github wallymathieu/FSharp.SExpression SExpression.fs
 nuget Argu 
 nuget FSharp.Core ~> 4 redirects: force
 nuget FAKE.Lib ~> 4
+nuget Expecto
+nuget Expecto.BenchmarkDotNet
+nuget Expecto.FsCheck
 
 group Build
   source https://nuget.org/api/v2
@@ -17,8 +20,3 @@ group Build
 
   github fsharp/FAKE modules/Octokit/Octokit.fsx
 
-group Test
-  source https://nuget.org/api/v2
-  
-  nuget NUnit ~> 2
-  nuget NUnit.Runners ~> 2

--- a/paket.dependencies
+++ b/paket.dependencies
@@ -3,6 +3,7 @@ redirects on
 framework >= net451
 
 nuget Chiron ~> 6
+github wallymathieu/FSharp.SExpression SExpression.fs
 nuget Argu 
 nuget FSharp.Core ~> 4 redirects: force
 nuget FAKE.Lib ~> 4

--- a/paket.lock
+++ b/paket.lock
@@ -1,76 +1,247 @@
 REDIRECTS: ON
-FRAMEWORK: >= NET451
+RESTRICTION: >= net451
 NUGET
   remote: https://api.nuget.org/v3/index.json
     Aether (8.1.2)
     Argu (3.7)
-      FSharp.Core (>= 4.0.1.7-alpha) - framework: >= net463
-      NETStandard.Library (>= 1.6) - framework: >= net463
-      System.Xml.XDocument (>= 4.0.11) - framework: >= net463
+      FSharp.Core (>= 4.0.1.7-alpha) - restriction: && (>= net451) (>= netstandard1.6)
+      NETStandard.Library (>= 1.6) - restriction: && (>= net451) (>= netstandard1.6)
+      System.Xml.XDocument (>= 4.0.11) - restriction: && (>= net451) (>= netstandard1.6)
+    BenchmarkDotNet (0.10.12)
+      BenchmarkDotNet.Core (>= 0.10.12) - restriction: || (&& (>= net451) (>= netcoreapp1.1)) (>= net46)
+      BenchmarkDotNet.Toolchains.Roslyn (>= 0.10.12) - restriction: >= net46
+    BenchmarkDotNet.Core (0.10.12) - restriction: || (&& (>= net451) (>= netcoreapp1.1)) (>= net46)
+      Microsoft.DotNet.InternalAbstractions (>= 1.0) - restriction: || (&& (>= net451) (>= netcoreapp1.1)) (>= net46)
+      Microsoft.DotNet.PlatformAbstractions (>= 1.1.1) - restriction: || (&& (>= net451) (>= netcoreapp1.1)) (>= net46)
+      Microsoft.Win32.Registry (>= 4.3) - restriction: || (&& (>= net451) (>= netcoreapp1.1)) (>= net46)
+      System.Threading.Tasks.Extensions (>= 4.3) - restriction: >= net46
+      System.ValueTuple (>= 4.3) - restriction: || (&& (>= net451) (>= netcoreapp1.1)) (>= net46)
+      System.Xml.XmlSerializer (>= 4.3) - restriction: || (&& (>= net451) (>= netcoreapp1.1)) (>= net46)
+    BenchmarkDotNet.Toolchains.Roslyn (0.10.12) - restriction: >= net46
+      BenchmarkDotNet.Core (>= 0.10.12) - restriction: >= net46
+      Microsoft.CodeAnalysis.CSharp (>= 2.4) - restriction: >= net46
+      System.Threading.Tasks (>= 4.3) - restriction: >= net46
     Chiron (6.2.1)
       Aether (>= 8.0.2 < 9.0)
       FParsec (>= 1.0 < 2.0)
+    Expecto (4.1.1)
+      Argu (>= 3.7)
+      FSharp.Core (>= 3.1.2.5)
+      Mono.Cecil (>= 0.9.6.4)
+    Expecto.BenchmarkDotNet (4.1.1)
+      BenchmarkDotNet (>= 0.10.3)
+      Expecto (>= 4.1.1)
+      FSharp.Core (>= 3.1.2.5)
+    Expecto.FsCheck (4.1.1)
+      Expecto (>= 4.1.1)
+      FsCheck (>= 2.8)
+      FSharp.Core (>= 3.1.2.5)
     FAKE.Lib (4.56)
     FParsec (1.0.2)
+    FsCheck (2.10.7)
+      FSharp.Core (>= 4.0.0.1)
     FSharp.Core (4.1.0.2) - redirects: force
-      System.ValueTuple (>= 4.3)
-    Microsoft.Win32.Primitives (4.3) - framework: >= net463
-    NETStandard.Library (1.6.1) - framework: >= net463
-      Microsoft.Win32.Primitives (>= 4.3) - framework: >= net46
-      System.AppContext (>= 4.3) - framework: >= net46
+      System.Collections (>= 4.0.11) - restriction: && (>= net451) (>= netstandard1.6)
+      System.Console (>= 4.0) - restriction: && (>= net451) (>= netstandard1.6)
+      System.Diagnostics.Debug (>= 4.0.11) - restriction: && (>= net451) (>= netstandard1.6)
+      System.Diagnostics.Tools (>= 4.0.1) - restriction: && (>= net451) (>= netstandard1.6)
+      System.Globalization (>= 4.0.11) - restriction: && (>= net451) (>= netstandard1.6)
+      System.IO (>= 4.1) - restriction: && (>= net451) (>= netstandard1.6)
+      System.Linq (>= 4.1) - restriction: && (>= net451) (>= netstandard1.6)
+      System.Linq.Expressions (>= 4.1) - restriction: && (>= net451) (>= netstandard1.6)
+      System.Linq.Queryable (>= 4.0.1) - restriction: && (>= net451) (>= netstandard1.6)
+      System.Net.Requests (>= 4.0.11) - restriction: && (>= net451) (>= netstandard1.6)
+      System.Reflection (>= 4.1) - restriction: && (>= net451) (>= netstandard1.6)
+      System.Reflection.Extensions (>= 4.0.1) - restriction: && (>= net451) (>= netstandard1.6)
+      System.Resources.ResourceManager (>= 4.0.1) - restriction: && (>= net451) (>= netstandard1.6)
+      System.Runtime (>= 4.1) - restriction: && (>= net451) (>= netstandard1.6)
+      System.Runtime.Extensions (>= 4.1) - restriction: && (>= net451) (>= netstandard1.6)
+      System.Runtime.Numerics (>= 4.0.1) - restriction: && (>= net451) (>= netstandard1.6)
+      System.Text.RegularExpressions (>= 4.1) - restriction: && (>= net451) (>= netstandard1.6)
+      System.Threading (>= 4.0.11) - restriction: && (>= net451) (>= netstandard1.6)
+      System.Threading.Tasks (>= 4.0.11) - restriction: && (>= net451) (>= netstandard1.6)
+      System.Threading.Tasks.Parallel (>= 4.0.1) - restriction: && (>= net451) (>= netstandard1.6)
+      System.Threading.Thread (>= 4.0) - restriction: && (>= net451) (>= netstandard1.6)
+      System.Threading.ThreadPool (>= 4.0.10) - restriction: && (>= net451) (>= netstandard1.6)
+      System.Threading.Timer (>= 4.0.1) - restriction: && (>= net451) (>= netstandard1.6)
+      System.ValueTuple (>= 4.3) - restriction: && (>= net451) (< netstandard1.6)
+    Microsoft.CodeAnalysis.Analyzers (2.6) - restriction: >= net46
+    Microsoft.CodeAnalysis.Common (2.6.1) - restriction: >= net46
+      Microsoft.CodeAnalysis.Analyzers (>= 1.1) - restriction: && (>= net451) (>= netstandard1.3)
+      System.AppContext (>= 4.3) - restriction: && (>= net451) (>= netstandard1.3)
+      System.Collections (>= 4.3) - restriction: && (>= net451) (>= netstandard1.3)
+      System.Collections.Concurrent (>= 4.3) - restriction: && (>= net451) (>= netstandard1.3)
+      System.Collections.Immutable (>= 1.3.1) - restriction: && (>= net451) (>= netstandard1.3)
+      System.Console (>= 4.3) - restriction: && (>= net451) (>= netstandard1.3)
+      System.Diagnostics.Debug (>= 4.3) - restriction: && (>= net451) (>= netstandard1.3)
+      System.Diagnostics.FileVersionInfo (>= 4.3) - restriction: && (>= net451) (>= netstandard1.3)
+      System.Diagnostics.StackTrace (>= 4.3) - restriction: && (>= net451) (>= netstandard1.3)
+      System.Diagnostics.Tools (>= 4.3) - restriction: && (>= net451) (>= netstandard1.3)
+      System.Dynamic.Runtime (>= 4.3) - restriction: && (>= net451) (>= netstandard1.3)
+      System.Globalization (>= 4.3) - restriction: && (>= net451) (>= netstandard1.3)
+      System.IO.Compression (>= 4.3) - restriction: && (>= net451) (>= netstandard1.3)
+      System.IO.FileSystem (>= 4.3) - restriction: && (>= net451) (>= netstandard1.3)
+      System.IO.FileSystem.Primitives (>= 4.3) - restriction: && (>= net451) (>= netstandard1.3)
+      System.Linq (>= 4.3) - restriction: && (>= net451) (>= netstandard1.3)
+      System.Linq.Expressions (>= 4.3) - restriction: && (>= net451) (>= netstandard1.3)
+      System.Reflection (>= 4.3) - restriction: && (>= net451) (>= netstandard1.3)
+      System.Reflection.Metadata (>= 1.4.2) - restriction: && (>= net451) (>= netstandard1.3)
+      System.Resources.ResourceManager (>= 4.3) - restriction: && (>= net451) (>= netstandard1.3)
+      System.Runtime (>= 4.3) - restriction: && (>= net451) (>= netstandard1.3)
+      System.Runtime.Extensions (>= 4.3) - restriction: && (>= net451) (>= netstandard1.3)
+      System.Runtime.InteropServices (>= 4.3) - restriction: && (>= net451) (>= netstandard1.3)
+      System.Runtime.Numerics (>= 4.3) - restriction: && (>= net451) (>= netstandard1.3)
+      System.Security.Cryptography.Algorithms (>= 4.3) - restriction: && (>= net451) (>= netstandard1.3)
+      System.Security.Cryptography.Encoding (>= 4.3) - restriction: && (>= net451) (>= netstandard1.3)
+      System.Security.Cryptography.X509Certificates (>= 4.3) - restriction: && (>= net451) (>= netstandard1.3)
+      System.Text.Encoding (>= 4.3) - restriction: && (>= net451) (>= netstandard1.3)
+      System.Text.Encoding.CodePages (>= 4.3) - restriction: && (>= net451) (>= netstandard1.3)
+      System.Text.Encoding.Extensions (>= 4.3) - restriction: && (>= net451) (>= netstandard1.3)
+      System.Threading (>= 4.3) - restriction: && (>= net451) (>= netstandard1.3)
+      System.Threading.Tasks (>= 4.3) - restriction: && (>= net451) (>= netstandard1.3)
+      System.Threading.Tasks.Parallel (>= 4.3) - restriction: && (>= net451) (>= netstandard1.3)
+      System.Threading.Thread (>= 4.3) - restriction: && (>= net451) (>= netstandard1.3)
+      System.ValueTuple (>= 4.3) - restriction: && (>= net451) (>= netstandard1.3)
+      System.Xml.ReaderWriter (>= 4.3) - restriction: && (>= net451) (>= netstandard1.3)
+      System.Xml.XDocument (>= 4.3) - restriction: && (>= net451) (>= netstandard1.3)
+      System.Xml.XmlDocument (>= 4.3) - restriction: && (>= net451) (>= netstandard1.3)
+      System.Xml.XPath.XDocument (>= 4.3) - restriction: && (>= net451) (>= netstandard1.3)
+    Microsoft.CodeAnalysis.CSharp (2.6.1) - restriction: >= net46
+      Microsoft.CodeAnalysis.Common (2.6.1)
+    Microsoft.DotNet.InternalAbstractions (1.0) - restriction: || (&& (>= net451) (>= netcoreapp1.1)) (>= net46)
+    Microsoft.DotNet.PlatformAbstractions (2.0.4) - restriction: || (&& (>= net451) (>= netcoreapp1.1)) (>= net46)
+    Microsoft.NETCore.Platforms (2.0.1) - restriction: || (&& (>= net451) (>= netstandard1.6)) (&& (>= net46) (< netstandard2.0))
+    Microsoft.Win32.Primitives (4.3) - restriction: || (&& (>= net451) (>= netstandard1.6)) (&& (>= net46) (< netstandard2.0))
+    Microsoft.Win32.Registry (4.4) - restriction: || (&& (>= net451) (>= netcoreapp1.1)) (>= net46)
+      System.Security.AccessControl (>= 4.4) - restriction: || (&& (>= monoandroid) (>= net451) (< netstandard1.3)) (&& (>= monotouch) (>= net451)) (&& (>= net451) (< net46) (>= netstandard2.0)) (&& (>= net451) (>= netcoreapp2.0)) (&& (>= net451) (>= xamarinios)) (&& (>= net451) (>= xamarinmac)) (&& (>= net451) (>= xamarintvos)) (&& (>= net451) (>= xamarinwatchos)) (>= net461)
+      System.Security.Principal.Windows (>= 4.4) - restriction: || (&& (>= monoandroid) (>= net451) (< netstandard1.3)) (&& (>= monotouch) (>= net451)) (&& (>= net451) (< net46) (>= netstandard2.0)) (&& (>= net451) (>= netcoreapp2.0)) (&& (>= net451) (>= xamarinios)) (&& (>= net451) (>= xamarinmac)) (&& (>= net451) (>= xamarintvos)) (&& (>= net451) (>= xamarinwatchos)) (>= net461)
+    Mono.Cecil (0.9.6.4)
+    NETStandard.Library (1.6.1) - restriction: || (&& (>= net451) (>= netstandard1.6)) (&& (>= net46) (< netstandard2.0))
+      Microsoft.NETCore.Platforms (>= 1.1)
+      Microsoft.Win32.Primitives (>= 4.3) - restriction: && (>= net451) (>= netstandard1.3)
+      System.AppContext (>= 4.3) - restriction: && (>= net451) (>= netstandard1.3)
+      System.Collections (>= 4.3)
       System.Collections.Concurrent (>= 4.3)
-      System.Console (>= 4.3) - framework: >= net46
+      System.Console (>= 4.3) - restriction: && (>= net451) (>= netstandard1.3)
+      System.Diagnostics.Debug (>= 4.3)
+      System.Diagnostics.Tools (>= 4.3)
       System.Diagnostics.Tracing (>= 4.3)
-      System.Globalization.Calendars (>= 4.3) - framework: >= net46
+      System.Globalization (>= 4.3)
+      System.Globalization.Calendars (>= 4.3) - restriction: && (>= net451) (>= netstandard1.3)
+      System.IO (>= 4.3)
       System.IO.Compression (>= 4.3)
-      System.IO.Compression.ZipFile (>= 4.3) - framework: >= net46
-      System.IO.FileSystem (>= 4.3) - framework: >= net46
-      System.IO.FileSystem.Primitives (>= 4.3) - framework: >= net46
+      System.IO.Compression.ZipFile (>= 4.3) - restriction: && (>= net451) (>= netstandard1.3)
+      System.IO.FileSystem (>= 4.3) - restriction: && (>= net451) (>= netstandard1.3)
+      System.IO.FileSystem.Primitives (>= 4.3) - restriction: && (>= net451) (>= netstandard1.3)
+      System.Linq (>= 4.3)
+      System.Linq.Expressions (>= 4.3)
       System.Net.Http (>= 4.3)
-      System.Net.Sockets (>= 4.3) - framework: >= net46
-      System.Runtime.Handles (>= 4.3) - framework: >= net46
+      System.Net.Primitives (>= 4.3)
+      System.Net.Sockets (>= 4.3) - restriction: && (>= net451) (>= netstandard1.3)
+      System.ObjectModel (>= 4.3)
+      System.Reflection (>= 4.3)
+      System.Reflection.Extensions (>= 4.3)
+      System.Reflection.Primitives (>= 4.3)
+      System.Resources.ResourceManager (>= 4.3)
+      System.Runtime (>= 4.3)
+      System.Runtime.Extensions (>= 4.3)
+      System.Runtime.Handles (>= 4.3) - restriction: && (>= net451) (>= netstandard1.3)
       System.Runtime.InteropServices (>= 4.3)
       System.Runtime.InteropServices.RuntimeInformation (>= 4.3)
       System.Runtime.Numerics (>= 4.3)
-      System.Security.Cryptography.Algorithms (>= 4.3) - framework: >= net46
-      System.Security.Cryptography.Encoding (>= 4.3) - framework: >= net46
-      System.Security.Cryptography.Primitives (>= 4.3) - framework: >= net46
-      System.Security.Cryptography.X509Certificates (>= 4.3) - framework: >= net46
+      System.Security.Cryptography.Algorithms (>= 4.3) - restriction: && (>= net451) (>= netstandard1.3)
+      System.Security.Cryptography.Encoding (>= 4.3) - restriction: && (>= net451) (>= netstandard1.3)
+      System.Security.Cryptography.Primitives (>= 4.3) - restriction: && (>= net451) (>= netstandard1.3)
+      System.Security.Cryptography.X509Certificates (>= 4.3) - restriction: && (>= net451) (>= netstandard1.3)
+      System.Text.Encoding (>= 4.3)
+      System.Text.Encoding.Extensions (>= 4.3)
+      System.Text.RegularExpressions (>= 4.3)
+      System.Threading (>= 4.3)
+      System.Threading.Tasks (>= 4.3)
       System.Threading.Timer (>= 4.3)
-    System.AppContext (4.3) - framework: >= net463
-    System.Collections.Concurrent (4.3) - framework: >= net463
-    System.Console (4.3) - framework: >= net463
-    System.Diagnostics.Tracing (4.3) - framework: >= net463
-    System.Globalization.Calendars (4.3) - framework: >= net463
-    System.IO (4.3) - framework: >= net463
-    System.IO.Compression (4.3) - framework: >= net463
-    System.IO.Compression.ZipFile (4.3) - framework: >= net463
-    System.IO.FileSystem (4.3) - framework: >= net463
-      System.IO.FileSystem.Primitives (>= 4.3) - framework: >= net46
-    System.IO.FileSystem.Primitives (4.3)
-    System.Net.Http (4.3.1) - framework: >= net463
-      System.Security.Cryptography.X509Certificates (>= 4.3) - framework: >= net46
-    System.Net.Sockets (4.3) - framework: >= net463
-    System.Runtime (4.3)
-    System.Runtime.Handles (4.3) - framework: >= net463
-    System.Runtime.InteropServices (4.3) - framework: >= net463
-      System.Runtime (>= 4.3) - framework: >= net462
-    System.Runtime.InteropServices.RuntimeInformation (4.3) - framework: >= net463
-    System.Runtime.Numerics (4.3) - framework: >= net463
-    System.Security.Cryptography.Algorithms (4.3)
-      System.IO (>= 4.3) - framework: >= net463
-      System.Runtime (>= 4.3) - framework: >= net463
-      System.Security.Cryptography.Encoding (>= 4.3) - framework: >= net463
-      System.Security.Cryptography.Primitives (>= 4.3) - framework: net46, net461, >= net463
-    System.Security.Cryptography.Encoding (4.3)
-    System.Security.Cryptography.Primitives (4.3)
-    System.Security.Cryptography.X509Certificates (4.3)
-      System.Security.Cryptography.Algorithms (>= 4.3) - framework: >= net46
-      System.Security.Cryptography.Encoding (>= 4.3) - framework: >= net46
-    System.Threading.Timer (4.3) - framework: >= net463
+      System.Xml.ReaderWriter (>= 4.3)
+      System.Xml.XDocument (>= 4.3)
+    System.AppContext (4.3) - restriction: || (&& (>= net451) (>= netstandard1.6)) (>= net46)
+    System.Collections (4.3) - redirects: force, restriction: || (&& (>= net451) (>= netstandard1.6)) (>= net46)
+    System.Collections.Concurrent (4.3) - restriction: || (&& (>= net451) (>= netstandard1.6)) (>= net46)
+    System.Collections.Immutable (1.4) - restriction: >= net46
+      NETStandard.Library (>= 1.6.1) - restriction: && (>= net451) (< netstandard2.0)
+    System.Console (4.3) - redirects: force, restriction: || (&& (>= net451) (>= netstandard1.6)) (>= net46)
+    System.Diagnostics.Debug (4.3) - redirects: force, restriction: || (&& (>= net451) (>= netstandard1.6)) (>= net46)
+    System.Diagnostics.FileVersionInfo (4.3) - restriction: >= net46
+    System.Diagnostics.StackTrace (4.3) - restriction: >= net46
+    System.Diagnostics.Tools (4.3) - redirects: force, restriction: || (&& (>= net451) (>= netstandard1.6)) (>= net46)
+    System.Diagnostics.Tracing (4.3) - restriction: || (&& (>= net451) (>= netstandard1.6)) (&& (>= net46) (< netstandard2.0))
+    System.Dynamic.Runtime (4.3) - restriction: >= net46
+    System.Globalization (4.3) - redirects: force, restriction: || (&& (>= net451) (>= netstandard1.6)) (>= net46)
+    System.Globalization.Calendars (4.3) - restriction: || (&& (>= net451) (>= netstandard1.6)) (&& (>= net46) (< netstandard2.0))
+    System.IO (4.3) - redirects: force, restriction: || (&& (>= dnxcore50) (>= net46)) (&& (>= net451) (>= netstandard1.6)) (&& (>= net46) (< netstandard2.0)) (>= net463)
+    System.IO.Compression (4.3) - restriction: || (&& (>= net451) (>= netstandard1.6)) (>= net46)
+    System.IO.Compression.ZipFile (4.3) - restriction: || (&& (>= net451) (>= netstandard1.6)) (&& (>= net46) (< netstandard2.0))
+    System.IO.FileSystem (4.3) - restriction: || (&& (>= net451) (>= netstandard1.6)) (>= net46)
+      System.IO.FileSystem.Primitives (>= 4.3) - restriction: || (&& (>= net451) (>= netstandard1.3)) (>= net46)
+    System.IO.FileSystem.Primitives (4.3) - restriction: || (&& (>= net451) (>= netstandard1.6)) (>= net46)
+    System.Linq (4.3) - redirects: force, restriction: || (&& (>= net451) (>= netstandard1.6)) (>= net46)
+    System.Linq.Expressions (4.3) - redirects: force, restriction: || (&& (>= net451) (>= netstandard1.6)) (>= net46)
+    System.Linq.Queryable (4.3) - redirects: force, restriction: && (>= net451) (>= netstandard1.6)
+    System.Net.Http (4.3.1) - restriction: || (&& (>= net451) (>= netstandard1.6)) (&& (>= net46) (< netstandard2.0))
+      System.Security.Cryptography.X509Certificates (>= 4.3) - restriction: || (&& (>= dnxcore50) (>= net451)) (&& (< net45) (>= net451) (>= netstandard1.3) (< netstandard1.6)) (&& (< net45) (>= net451) (>= netstandard1.6)) (>= net46)
+    System.Net.Primitives (4.3) - restriction: || (&& (>= net451) (>= netstandard1.6)) (&& (>= net46) (< netstandard2.0))
+    System.Net.Requests (4.3) - redirects: force, restriction: && (>= net451) (>= netstandard1.6)
+    System.Net.Sockets (4.3) - restriction: || (&& (>= net451) (>= netstandard1.6)) (&& (>= net46) (< netstandard2.0))
+    System.ObjectModel (4.3) - restriction: || (&& (>= net451) (>= netstandard1.6)) (&& (>= net46) (< netstandard2.0))
+    System.Reflection (4.3) - redirects: force, restriction: || (&& (>= net451) (>= netstandard1.6)) (>= net46)
+    System.Reflection.Extensions (4.3) - redirects: force, restriction: || (&& (>= net451) (>= netstandard1.6)) (&& (>= net46) (< netstandard2.0))
+    System.Reflection.Metadata (1.5) - restriction: >= net46
+      NETStandard.Library (>= 1.6.1) - restriction: && (>= net451) (< netstandard2.0)
+      System.Collections.Immutable (>= 1.4)
+    System.Reflection.Primitives (4.3) - restriction: || (&& (>= net451) (>= netstandard1.6)) (&& (>= net46) (< netstandard2.0))
+    System.Resources.ResourceManager (4.3) - redirects: force, restriction: || (&& (>= net451) (>= netstandard1.6)) (>= net46)
+    System.Runtime (4.3) - redirects: force, restriction: || (&& (>= net451) (>= netcoreapp1.1)) (&& (>= net451) (>= netstandard1.6)) (>= net46)
+    System.Runtime.Extensions (4.3) - redirects: force, restriction: || (&& (>= net451) (>= netstandard1.6)) (>= net46)
+    System.Runtime.Handles (4.3) - restriction: || (&& (>= net451) (>= netstandard1.6)) (&& (>= net46) (< netstandard2.0))
+    System.Runtime.InteropServices (4.3) - restriction: || (&& (>= net451) (>= netstandard1.6)) (>= net46)
+      System.Runtime (>= 4.3) - restriction: || (&& (>= dnxcore50) (>= net451)) (&& (< net45) (>= net451) (< netstandard1.2)) (&& (< net45) (>= net451) (>= netstandard1.3) (< netstandard1.5)) (&& (< net45) (>= net451) (< netstandard1.3)) (&& (< net45) (>= net451) (>= netstandard1.5)) (&& (>= net451) (>= netcoreapp1.1)) (>= net462)
+    System.Runtime.InteropServices.RuntimeInformation (4.3) - restriction: || (&& (>= net451) (>= netstandard1.6)) (&& (>= net46) (< netstandard2.0))
+    System.Runtime.Numerics (4.3) - redirects: force, restriction: || (&& (>= net451) (>= netstandard1.6)) (>= net46)
+    System.Security.AccessControl (4.4.1) - restriction: || (&& (>= monoandroid) (>= net451) (>= netcoreapp1.1) (< netstandard1.3)) (&& (>= monoandroid) (>= net46) (< netstandard1.3)) (&& (>= monotouch) (>= net451) (>= netcoreapp1.1)) (&& (>= monotouch) (>= net46)) (&& (>= net451) (>= netcoreapp1.1) (>= netstandard2.0)) (&& (>= net451) (>= netcoreapp1.1) (>= xamarinios)) (&& (>= net451) (>= netcoreapp1.1) (>= xamarinmac)) (&& (>= net451) (>= netcoreapp1.1) (>= xamarintvos)) (&& (>= net451) (>= netcoreapp1.1) (>= xamarinwatchos)) (&& (>= net451) (>= netcoreapp2.0)) (&& (>= net46) (>= netcoreapp2.0)) (&& (>= net46) (>= xamarinios)) (&& (>= net46) (>= xamarinmac)) (&& (>= net46) (>= xamarintvos)) (&& (>= net46) (>= xamarinwatchos)) (>= net461)
+      System.Security.Principal.Windows (>= 4.4) - restriction: || (&& (>= monoandroid) (>= net451)) (&& (>= monotouch) (>= net451)) (&& (>= net451) (< net46) (>= netstandard1.3) (< netstandard2.0)) (&& (>= net451) (< net46) (>= netstandard2.0)) (&& (>= net451) (>= netcoreapp2.0)) (&& (>= net451) (>= xamarinios)) (&& (>= net451) (>= xamarinmac)) (&& (>= net451) (>= xamarintvos)) (&& (>= net451) (>= xamarinwatchos)) (&& (>= net46) (< netstandard2.0)) (>= net461)
+    System.Security.Cryptography.Algorithms (4.3) - restriction: || (&& (>= net451) (>= netstandard1.6)) (>= net46)
+      System.IO (>= 4.3) - restriction: || (&& (>= dnxcore50) (>= net451)) (&& (>= net451) (< net46) (>= netstandard1.3) (< netstandard1.4)) (&& (>= net451) (< net46) (>= netstandard1.4) (< netstandard1.6)) (&& (>= net451) (< net46) (>= netstandard1.6)) (>= net463)
+      System.Runtime (>= 4.3) - restriction: || (&& (>= dnxcore50) (>= net451)) (&& (>= net451) (< net46) (>= netstandard1.3) (< netstandard1.4)) (&& (>= net451) (< net46) (>= netstandard1.4) (< netstandard1.6)) (&& (>= net451) (< net46) (>= netstandard1.6)) (>= net463)
+      System.Security.Cryptography.Encoding (>= 4.3) - restriction: || (&& (>= dnxcore50) (>= net451)) (&& (>= net451) (< net46) (>= netstandard1.6)) (>= net463)
+      System.Security.Cryptography.Primitives (>= 4.3) - restriction: || (&& (>= dnxcore50) (>= net451)) (&& (>= net451) (< net46) (>= netstandard1.3) (< netstandard1.4)) (&& (>= net451) (< net46) (>= netstandard1.4) (< netstandard1.6)) (&& (>= net451) (< net46) (>= netstandard1.6)) (&& (>= net46) (< netstandard1.4)) (&& (>= net461) (< netstandard1.6)) (>= net463)
+    System.Security.Cryptography.Encoding (4.3) - restriction: || (&& (>= net451) (>= netstandard1.6)) (>= net46) (&& (>= net463) (>= netstandard1.6))
+    System.Security.Cryptography.Primitives (4.3) - restriction: || (&& (>= dnxcore50) (>= net46)) (&& (>= net451) (>= netstandard1.6)) (&& (>= net46) (< netstandard1.4)) (&& (>= net461) (< netstandard1.6)) (>= net463)
+    System.Security.Cryptography.X509Certificates (4.3) - restriction: || (&& (>= net451) (>= netstandard1.6)) (>= net46)
+      System.Security.Cryptography.Algorithms (>= 4.3) - restriction: || (&& (>= dnxcore50) (>= net451)) (&& (>= net451) (< net46) (>= netstandard1.3) (< netstandard1.4)) (&& (>= net451) (< net46) (>= netstandard1.4) (< netstandard1.6)) (&& (>= net451) (< net46) (>= netstandard1.6)) (&& (>= net46) (< netstandard1.4)) (>= net461)
+      System.Security.Cryptography.Encoding (>= 4.3) - restriction: || (&& (>= dnxcore50) (>= net451)) (&& (>= net451) (< net46) (>= netstandard1.3) (< netstandard1.4)) (&& (>= net451) (< net46) (>= netstandard1.4) (< netstandard1.6)) (&& (>= net451) (< net46) (>= netstandard1.6)) (&& (>= net46) (< netstandard1.4)) (>= net461)
+    System.Security.Principal.Windows (4.4.1) - restriction: || (&& (>= monoandroid) (>= net451) (>= netcoreapp1.1) (< netstandard1.3)) (&& (>= monoandroid) (>= net46) (< netstandard1.3)) (&& (>= monotouch) (>= net451) (>= netcoreapp1.1)) (&& (>= monotouch) (>= net46)) (&& (>= net451) (>= netcoreapp1.1) (>= netstandard2.0)) (&& (>= net451) (>= netcoreapp1.1) (>= xamarinios)) (&& (>= net451) (>= netcoreapp1.1) (>= xamarinmac)) (&& (>= net451) (>= netcoreapp1.1) (>= xamarintvos)) (&& (>= net451) (>= netcoreapp1.1) (>= xamarinwatchos)) (&& (>= net451) (>= netcoreapp2.0)) (&& (>= net46) (>= netcoreapp2.0)) (&& (>= net46) (>= xamarinios)) (&& (>= net46) (>= xamarinmac)) (&& (>= net46) (>= xamarintvos)) (&& (>= net46) (>= xamarinwatchos)) (>= net461)
+    System.Text.Encoding (4.3) - restriction: || (&& (>= net451) (>= netstandard1.6)) (>= net46)
+    System.Text.Encoding.CodePages (4.4) - restriction: >= net46
+    System.Text.Encoding.Extensions (4.3) - restriction: || (&& (>= net451) (>= netstandard1.6)) (>= net46)
+    System.Text.RegularExpressions (4.3) - redirects: force, restriction: || (&& (>= net451) (>= netstandard1.6)) (&& (>= net46) (< netstandard2.0))
+    System.Threading (4.3) - redirects: force, restriction: || (&& (>= net451) (>= netstandard1.6)) (>= net46)
+    System.Threading.Tasks (4.3) - redirects: force, restriction: || (&& (>= net451) (>= netstandard1.6)) (>= net46)
+    System.Threading.Tasks.Extensions (4.4) - restriction: >= net46
+      System.Collections (>= 4.3) - restriction: && (>= net451) (< netstandard2.0)
+      System.Runtime (>= 4.3) - restriction: && (>= net451) (< netstandard2.0)
+      System.Threading.Tasks (>= 4.3) - restriction: && (>= net451) (< netstandard2.0)
+    System.Threading.Tasks.Parallel (4.3) - redirects: force, restriction: || (&& (>= net451) (>= netstandard1.6)) (>= net46)
+    System.Threading.Thread (4.3) - redirects: force, restriction: || (&& (>= net451) (>= netstandard1.6)) (>= net46)
+    System.Threading.ThreadPool (4.3) - redirects: force, restriction: && (>= net451) (>= netstandard1.6)
+    System.Threading.Timer (4.3) - redirects: force, restriction: || (&& (>= net451) (>= netstandard1.6)) (&& (>= net46) (< netstandard2.0))
     System.ValueTuple (4.3) - redirects: force
-    System.Xml.XDocument (4.3) - framework: >= net463
-
+    System.Xml.ReaderWriter (4.3.1) - restriction: || (&& (>= net451) (>= netstandard1.6)) (>= net46)
+    System.Xml.XDocument (4.3) - restriction: || (&& (>= net451) (>= netstandard1.6)) (>= net46)
+    System.Xml.XmlDocument (4.3) - restriction: >= net46
+    System.Xml.XmlSerializer (4.3) - restriction: || (&& (>= net451) (>= netcoreapp1.1)) (>= net46)
+    System.Xml.XPath (4.3) - restriction: >= net46
+    System.Xml.XPath.XDocument (4.3) - restriction: >= net46
+      System.Xml.XPath (>= 4.3) - restriction: || (&& (>= net451) (>= netstandard1.3)) (>= net46)
+GITHUB
+  remote: wallymathieu/FSharp.SExpression
+    SExpression.fs (16a9c13d6d6763504296b5dedfafe1f6a8278b41)
 GROUP Build
 NUGET
   remote: https://www.nuget.org/api/v2
@@ -81,21 +252,16 @@ NUGET
       FSharpVSPowerTools.Core (>= 2.3 < 2.4)
     FSharpVSPowerTools.Core (2.3)
       FSharp.Compiler.Service (>= 2.0.0.3)
-    Microsoft.Bcl (1.1.10) - framework: net10, net11, net20, net30, net35, net40, net40-full
+    Microsoft.Bcl (1.1.10) - restriction: || (== net10) (== net11) (== net20) (== net30) (== net35) (== net40)
       Microsoft.Bcl.Build (>= 1.0.14)
-    Microsoft.Bcl.Build (1.0.21) - import_targets: false, framework: net10, net11, net20, net30, net35, net40, net40-full
-    Microsoft.Net.Http (2.2.29) - framework: net10, net11, net20, net30, net35, net40, net40-full
+    Microsoft.Bcl.Build (1.0.21) - import_targets: false, restriction: || (== net10) (== net11) (== net20) (== net30) (== net35) (== net40)
+    Microsoft.Net.Http (2.2.29) - restriction: || (== net10) (== net11) (== net20) (== net30) (== net35) (== net40)
       Microsoft.Bcl (>= 1.1.10)
       Microsoft.Bcl.Build (>= 1.0.14)
     Octokit (0.24)
-      Microsoft.Net.Http  - framework: net10, net11, net20, net30, net35, net40, net40-full
+      Microsoft.Net.Http  - restriction: || (== net10) (== net11) (== net20) (== net30) (== net35) (== net40)
     SourceLink.Fake (1.1)
 GITHUB
   remote: fsharp/FAKE
     modules/Octokit/Octokit.fsx (0cca21da332895437de5785210610bd055a77ac2)
       Octokit (>= 0.20)
-GROUP Test
-NUGET
-  remote: https://www.nuget.org/api/v2
-    NUnit (2.6.4)
-    NUnit.Runners (2.6.4)

--- a/src/SynVer.FAKE/SynVer.FAKE.fsproj
+++ b/src/SynVer.FAKE/SynVer.FAKE.fsproj
@@ -1,7 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
-
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -68,7 +67,7 @@
     <Content Include="App.config" />
   </ItemGroup>
   <Choose>
-    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.5.1' Or $(TargetFrameworkVersion) == 'v4.5.2' Or $(TargetFrameworkVersion) == 'v4.5.3' Or $(TargetFrameworkVersion) == 'v4.6' Or $(TargetFrameworkVersion) == 'v4.6.1' Or $(TargetFrameworkVersion) == 'v4.6.2' Or $(TargetFrameworkVersion) == 'v4.6.3')">
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.5.1' Or $(TargetFrameworkVersion) == 'v4.5.2' Or $(TargetFrameworkVersion) == 'v4.5.3' Or $(TargetFrameworkVersion) == 'v4.6' Or $(TargetFrameworkVersion) == 'v4.6.1' Or $(TargetFrameworkVersion) == 'v4.6.2' Or $(TargetFrameworkVersion) == 'v4.6.3' Or $(TargetFrameworkVersion) == 'v4.7' Or $(TargetFrameworkVersion) == 'v4.7.1')">
       <ItemGroup>
         <Reference Include="FakeLib">
           <HintPath>..\..\packages\FAKE.Lib\lib\net451\FakeLib.dll</HintPath>
@@ -79,7 +78,7 @@
     </When>
   </Choose>
   <Choose>
-    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.5.1' Or $(TargetFrameworkVersion) == 'v4.5.2' Or $(TargetFrameworkVersion) == 'v4.5.3' Or $(TargetFrameworkVersion) == 'v4.6' Or $(TargetFrameworkVersion) == 'v4.6.1' Or $(TargetFrameworkVersion) == 'v4.6.2' Or $(TargetFrameworkVersion) == 'v4.6.3')">
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.5.1' Or $(TargetFrameworkVersion) == 'v4.5.2' Or $(TargetFrameworkVersion) == 'v4.5.3' Or $(TargetFrameworkVersion) == 'v4.6' Or $(TargetFrameworkVersion) == 'v4.6.1' Or $(TargetFrameworkVersion) == 'v4.6.2' Or $(TargetFrameworkVersion) == 'v4.6.3' Or $(TargetFrameworkVersion) == 'v4.7' Or $(TargetFrameworkVersion) == 'v4.7.1')">
       <ItemGroup>
         <Reference Include="FSharp.Core">
           <HintPath>..\..\packages\FSharp.Core\lib\net45\FSharp.Core.dll</HintPath>
@@ -90,7 +89,127 @@
     </When>
   </Choose>
   <Choose>
-    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.5.1' Or $(TargetFrameworkVersion) == 'v4.5.2' Or $(TargetFrameworkVersion) == 'v4.5.3' Or $(TargetFrameworkVersion) == 'v4.6' Or $(TargetFrameworkVersion) == 'v4.6.1' Or $(TargetFrameworkVersion) == 'v4.6.2' Or $(TargetFrameworkVersion) == 'v4.6.3')">
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.6' Or $(TargetFrameworkVersion) == 'v4.6.1' Or $(TargetFrameworkVersion) == 'v4.6.2' Or $(TargetFrameworkVersion) == 'v4.6.3' Or $(TargetFrameworkVersion) == 'v4.7' Or $(TargetFrameworkVersion) == 'v4.7.1')">
+      <ItemGroup>
+        <Reference Include="System.Console">
+          <HintPath>..\..\packages\System.Console\lib\net46\System.Console.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Choose>
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.6.2' Or $(TargetFrameworkVersion) == 'v4.6.3' Or $(TargetFrameworkVersion) == 'v4.7' Or $(TargetFrameworkVersion) == 'v4.7.1')">
+      <ItemGroup>
+        <Reference Include="System.IO">
+          <HintPath>..\..\packages\System.IO\lib\net462\System.IO.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Choose>
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.6.3' Or $(TargetFrameworkVersion) == 'v4.7' Or $(TargetFrameworkVersion) == 'v4.7.1')">
+      <ItemGroup>
+        <Reference Include="System.Linq">
+          <HintPath>..\..\packages\System.Linq\lib\net463\System.Linq.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Choose>
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.6.3' Or $(TargetFrameworkVersion) == 'v4.7' Or $(TargetFrameworkVersion) == 'v4.7.1')">
+      <ItemGroup>
+        <Reference Include="System.Linq.Expressions">
+          <HintPath>..\..\packages\System.Linq.Expressions\lib\net463\System.Linq.Expressions.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Choose>
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.6.2' Or $(TargetFrameworkVersion) == 'v4.6.3' Or $(TargetFrameworkVersion) == 'v4.7' Or $(TargetFrameworkVersion) == 'v4.7.1')">
+      <ItemGroup>
+        <Reference Include="System.Reflection">
+          <HintPath>..\..\packages\System.Reflection\lib\net462\System.Reflection.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Choose>
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.6' Or $(TargetFrameworkVersion) == 'v4.6.1')">
+      <ItemGroup>
+        <Reference Include="System.ComponentModel.Composition">
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.6.2' Or $(TargetFrameworkVersion) == 'v4.6.3' Or $(TargetFrameworkVersion) == 'v4.7' Or $(TargetFrameworkVersion) == 'v4.7.1')">
+      <ItemGroup>
+        <Reference Include="System.ComponentModel.Composition">
+          <Paket>True</Paket>
+        </Reference>
+        <Reference Include="System.Runtime">
+          <HintPath>..\..\packages\System.Runtime\lib\net462\System.Runtime.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Choose>
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.6.2' Or $(TargetFrameworkVersion) == 'v4.6.3' Or $(TargetFrameworkVersion) == 'v4.7' Or $(TargetFrameworkVersion) == 'v4.7.1')">
+      <ItemGroup>
+        <Reference Include="System.Runtime.Extensions">
+          <HintPath>..\..\packages\System.Runtime.Extensions\lib\net462\System.Runtime.Extensions.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Choose>
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.6.3' Or $(TargetFrameworkVersion) == 'v4.7' Or $(TargetFrameworkVersion) == 'v4.7.1')">
+      <ItemGroup>
+        <Reference Include="System.Text.RegularExpressions">
+          <HintPath>..\..\packages\System.Text.RegularExpressions\lib\net463\System.Text.RegularExpressions.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Choose>
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.6' Or $(TargetFrameworkVersion) == 'v4.6.1' Or $(TargetFrameworkVersion) == 'v4.6.2' Or $(TargetFrameworkVersion) == 'v4.6.3' Or $(TargetFrameworkVersion) == 'v4.7' Or $(TargetFrameworkVersion) == 'v4.7.1')">
+      <ItemGroup>
+        <Reference Include="System.Threading.Thread">
+          <HintPath>..\..\packages\System.Threading.Thread\lib\net46\System.Threading.Thread.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Choose>
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And $(TargetFrameworkVersion) == 'v4.7.1'">
+      <ItemGroup>
+        <Reference Include="System.Threading.ThreadPool">
+          <HintPath>..\..\packages\System.Threading.ThreadPool\lib\net46\System.Threading.ThreadPool.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Choose>
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.5.1' Or $(TargetFrameworkVersion) == 'v4.5.2' Or $(TargetFrameworkVersion) == 'v4.5.3' Or $(TargetFrameworkVersion) == 'v4.6' Or $(TargetFrameworkVersion) == 'v4.6.1' Or $(TargetFrameworkVersion) == 'v4.6.2' Or $(TargetFrameworkVersion) == 'v4.6.3' Or $(TargetFrameworkVersion) == 'v4.7' Or $(TargetFrameworkVersion) == 'v4.7.1')">
       <ItemGroup>
         <Reference Include="System.ValueTuple">
           <HintPath>..\..\packages\System.ValueTuple\lib\netstandard1.0\System.ValueTuple.dll</HintPath>

--- a/src/SynVer.Lib/Lson.fs
+++ b/src/SynVer.Lib/Lson.fs
@@ -1,0 +1,13 @@
+﻿module SynVer.Lson
+open SynVer.Serialization
+open FSharp.SExpression
+let serialize (p:Package) = Package.serialize p |> print
+let tryDeserialize v :Package option=
+  match parse v with
+  | [e] -> Package.deSerialize e
+  | _ -> None
+
+let deserialize v :Package =
+  match tryDeserialize v with
+  | None -> failwithf "expected serialized package ! %s" v
+  | Some p -> p

--- a/src/SynVer.Lib/Reflect.fs
+++ b/src/SynVer.Lib/Reflect.fs
@@ -51,15 +51,10 @@ module Reflect =
           | _ -> fromTypeFlags()
       | _ , Some _ ->NetType.Struct
       | _ , _ -> fromTypeFlags()
-  let private memoize f =    
-    let cache = new System.Collections.Generic.Dictionary<_, _>()
-    (fun x ->
-        match cache.TryGetValue(x) with
-        | true, v -> v
-        | false, _ ->
-          let v = f(x) 
-          cache.Add(x, v)
-          v)
+  let private memoize f =
+    let cache = new System.Collections.Concurrent.ConcurrentDictionary<'x, 'y>()
+    (fun (x:'x) ->
+        cache.GetOrAdd(x, System.Func<'x,'y>(f)))
 
   [<CompiledName("TagNetType")>]
   let tagNetType = memoize _tagNetType

--- a/src/SynVer.Lib/Serialization.fs
+++ b/src/SynVer.Lib/Serialization.fs
@@ -1,0 +1,241 @@
+﻿module internal SynVer.Serialization
+open FSharp.SExpression
+type E = Expression
+
+module private Enums =
+  let serialize (e : 'e when 'e :> System.Enum and 'e : (new:unit->'e) and 'e : struct) =
+      e.ToString "G"
+      |> String
+  let deSerialize<'e when 'e :> System.Enum and 'e : (new:unit->'e) and 'e : struct> v =
+      match v with
+      | String s ->
+          match System.Enum.TryParse<'e> s with
+          | true, x -> Some x
+          | _ -> None
+      | _ -> None
+module private Bool =
+  let serialize (b:bool) =
+      b.ToString ()
+      |> String
+  let deSerialize v =
+      match v with
+      | String s ->
+          match System.Boolean.TryParse s with
+          | true, x -> Some x
+          | _ -> None
+      | _ -> None
+module Type=
+  let serialize  (x:Typ) =
+    E.List [ E.Symbol "typ" ; E.String x.FullName ]
+  let deSerialize v : Typ option=
+      match v with 
+      | E.List [ 
+                E.Symbol "typ"; E.String n
+               ] -> Some { FullName = n}
+      | _ -> None
+
+
+module Parameter=
+  let deSerialize v : Parameter option=
+      match v with 
+      | E.List [ E.Symbol "typ"; typ; E.Symbol "name"; E.String n ] -> 
+        Type.deSerialize typ |> Option.map ( fun t -> { Type = t; Name = n } )
+      | _ -> None
+  let serialize  (x:Parameter) =
+    E.List [ E.Symbol "typ" ; Type.serialize x.Type; E.Symbol "name"; E.String x.Name]
+
+module ConstructorLike=
+       let deSerialize v : ConstructorLike option=
+          match v with 
+          | E.List (E.Symbol "typ" :: typ:: E.Symbol "params" :: [E.List parameters]) -> 
+            let p= parameters |> List.map Parameter.deSerialize 
+            if List.exists Option.isNone p then
+              None
+            else
+              Type.deSerialize typ |> Option.map ( fun t -> { Type = t; Parameters = p |> List.map Option.get } )
+          | _ -> None
+
+       let serialize  (x:ConstructorLike) =
+          E.List [ E.Symbol "typ" ; Type.serialize x.Type; E.Symbol "params"; E.List (List.map Parameter.serialize x.Parameters)]
+
+module MethodLike=
+  let deSerialize v : MethodLike option=
+      match v with 
+          | E.List [
+                    E.Symbol "typ" ; typ; 
+                    E.Symbol "instance" ; instance
+                    E.Symbol "name" ; E.String name
+                    E.Symbol "result"; result
+                    E.Symbol "params" ; E.List parameters
+                   ] -> 
+            let p= parameters |> List.map Parameter.deSerialize  
+            if List.exists Option.isNone p then
+              None
+            else
+              match (Enums.deSerialize instance, Type.deSerialize typ, Type.deSerialize result) with 
+              | (Some i, Some t, Some r) ->
+                Some { Type = t; Instance=i; Name=name; Result=r ; Parameters = p |> List.map Option.get } 
+              | _ ->
+                None
+          | _ -> None
+ 
+  let serialize  (x:MethodLike) =
+      E.List (
+        [
+          E.Symbol "typ" ; Type.serialize x.Type
+          E.Symbol "instance" ; Enums.serialize x.Instance
+          E.Symbol "name" ; String x.Name
+          E.Symbol "result" ; Type.serialize x.Result
+          E.Symbol "params" ; E.List (List.map Parameter.serialize x.Parameters)
+        ] )
+
+module FieldLike=
+  let deSerialize v : FieldLike option=
+      match v with 
+      | E.List [
+                E.Symbol "typ" ; typ; 
+                E.Symbol "instance" ; instance
+                E.Symbol "name" ; E.String name
+                E.Symbol "result"; result
+               ] -> 
+          match (Enums.deSerialize instance, Type.deSerialize typ, Type.deSerialize result) with 
+          | (Some i, Some t, Some r) ->
+            Some { Type = t; Instance=i; Name=name; Result=r }
+          | _ ->
+            None
+      | _ -> None
+
+  let serialize (x:FieldLike) =
+      E.List (
+        [
+          E.Symbol "typ" ; Type.serialize x.Type
+          E.Symbol "instance" ; Enums.serialize x.Instance
+          E.Symbol "name" ; String x.Name
+          E.Symbol "result" ; Type.serialize x.Result
+        ] )
+
+
+module Member=
+  let deSerialize v : Member option =
+    match v with
+    |  E.List [ E.Symbol "RecordConstructor"; c] -> 
+        ConstructorLike.deSerialize c |> Option.map RecordConstructor
+    | E.List [ E.Symbol "Constructor";c ]-> 
+        ConstructorLike.deSerialize c |> Option.map Constructor
+    | E.List [ E.Symbol "UnionConstructor"; typ; ctor ]-> 
+        match ( ConstructorLike.deSerialize ctor, Type.deSerialize typ) with
+        | (Some c, Some t) -> UnionConstructor (t,c) |> Some
+        | _ -> None
+    | E.List [ E.Symbol "Event";m ]-> MethodLike.deSerialize m |> Option.map Event
+    | E.List [ E.Symbol "Field";f ]-> FieldLike.deSerialize f |> Option.map Field
+    | E.List [ E.Symbol "Method";m ]-> MethodLike.deSerialize m |> Option.map Method
+    | E.List [ E.Symbol "Property";m ]-> FieldLike.deSerialize m |> Option.map Property
+    | E.List [ 
+              E.Symbol "UnionCase"; 
+              E.Symbol "type"; typ; 
+              E.Symbol "name"; E.String name;
+              E.Symbol "params"; E.List parameters
+             ]-> 
+        let p= parameters |> List.map Parameter.deSerialize 
+        if List.exists Option.isNone p then
+          None
+        else
+          Type.deSerialize typ |> Option.map ( fun t -> UnionCase (t,name, p |> List.map Option.get )) 
+    | E.List [ 
+              E.Symbol "EnumValue"; 
+              E.Symbol "type"; typ; 
+              E.Symbol "name"; E.String name;
+              E.Symbol "value"; E.String value
+             ]-> 
+        Type.deSerialize typ |> Option.map ( fun t -> EnumValue (t, name, value))
+    | _ -> None
+  let serialize  (x: Member) =
+      match x with
+      | RecordConstructor c -> E.List [ E.Symbol "RecordConstructor"; ConstructorLike.serialize c ]
+      | Constructor c -> E.List [ E.Symbol "Constructor"; ConstructorLike.serialize c ]
+      | UnionConstructor (t,c) -> E.List [ E.Symbol "UnionConstructor"; Type.serialize t; ConstructorLike.serialize c ]
+      | Event e ->E.List [ E.Symbol "Event"; MethodLike.serialize e]
+      | Field e ->E.List [ E.Symbol "Field"; FieldLike.serialize e]
+      | Method e ->E.List [ E.Symbol "Method"; MethodLike.serialize e]
+      | Property e ->E.List [ E.Symbol "Property"; FieldLike.serialize e]
+      | UnionCase (typ,name,param) ->
+        E.List [
+          E.Symbol "UnionCase"
+          E.Symbol "type"; Type.serialize typ
+          E.Symbol "name"; E.String name
+          E.Symbol "params"; E.List (List.map Parameter.serialize param)
+        ]
+      | EnumValue (typ,name,value) ->
+          E.List [
+            E.Symbol "EnumValue"
+            E.Symbol "type"; Type.serialize typ
+            E.Symbol "name"; E.String name
+            E.Symbol "value"; E.String value
+          ]
+
+module SurfaceOfType=
+  let deSerialize v : SurfaceOfType option=
+    match v with
+    | E.List [ 
+              E.Symbol "EnumValue"
+              E.Symbol "typ"; typ 
+              E.Symbol "netType"; netType
+              E.Symbol "members"; E.List members
+              E.Symbol "sumtype"; sumtype
+              E.Symbol "baseTyp"; baseTyp
+             ]-> 
+      match (Type.deSerialize typ, Enums.deSerialize netType, Bool.deSerialize sumtype ) with
+      | (Some t, Some n, Some s) ->
+        let m= members |> List.map Member.deSerialize 
+        if List.exists Option.isNone m then
+          None
+        else
+          Some { Type = t; NetType=n; Members=m |> List.map Option.get; SumType=s; BaseType=Type.deSerialize baseTyp }
+      | _ -> None
+    | _ -> None
+
+  let serialize (x:SurfaceOfType) =
+    E.List [ 
+              E.Symbol "EnumValue"
+              E.Symbol "typ"; Type.serialize x.Type
+              E.Symbol "netType"; Enums.serialize x.NetType
+              E.Symbol "members"; E.List <| List.map Member.serialize x.Members
+              E.Symbol "sumtype"; Bool.serialize x.SumType
+              E.Symbol "baseTyp"; (match x.BaseType with | Some b-> Type.serialize b | None -> E.List [])
+             ]
+
+module Namespace=
+  let deSerialize v : Namespace option=
+    match v with 
+    | E.List [
+              E.Symbol "namespace" ; E.String namespace'
+              E.Symbol "types" ; E.List types
+             ] -> 
+         let ts= types |> List.map SurfaceOfType.deSerialize 
+         if List.exists Option.isNone ts then
+           None
+         else
+           Some { Namespace=namespace';Types=ts|>List.map Option.get }
+    | _ -> None
+  let serialize  (x:Namespace) =
+    E.List [
+             E.Symbol "namespace" ; E.String x.Namespace
+             E.Symbol "types" ; E.List <| List.map SurfaceOfType.serialize x.Types
+           ]
+
+module Package=
+  let deSerialize v : Package option=
+    match v with 
+    | E.List [
+              E.Symbol "namespaces" ; E.List namespaces
+             ] -> 
+         let ns= namespaces |> List.map Namespace.deSerialize 
+         if List.exists Option.isNone ns then
+           None
+         else
+           Some { Namespaces = ns|>List.map Option.get }
+    | _ -> None
+  let serialize  (x:Package) =
+    E.List [
+            E.Symbol "namespaces" ; E.List <| List.map Namespace.serialize x.Namespaces
+           ]

--- a/src/SynVer.Lib/SynVer.Lib.fsproj
+++ b/src/SynVer.Lib/SynVer.Lib.fsproj
@@ -1,4 +1,4 @@
-<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+﻿<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -59,7 +59,13 @@
   -->
   <Import Project="..\..\.paket\paket.targets" />
   <ItemGroup>
+    <Compile Include="..\..\paket-files\wallymathieu\FSharp.SExpression\SExpression.fs">
+      <Paket>True</Paket>
+      <Link>paket-files/SExpression.fs</Link>
+    </Compile>
     <Compile Include="Models.fs" />
+    <Compile Include="Serialization.fs" />
+    <Compile Include="Lson.fs" />
     <Compile Include="Reflect.fs" />
     <Compile Include="Compare.fs" />
     <Compile Include="SurfaceArea.fs" />
@@ -78,45 +84,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <Choose>
-    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.5.1' Or $(TargetFrameworkVersion) == 'v4.5.2' Or $(TargetFrameworkVersion) == 'v4.5.3' Or $(TargetFrameworkVersion) == 'v4.6' Or $(TargetFrameworkVersion) == 'v4.6.1' Or $(TargetFrameworkVersion) == 'v4.6.2' Or $(TargetFrameworkVersion) == 'v4.6.3')">
-      <ItemGroup>
-        <Reference Include="Aether">
-          <HintPath>..\..\packages\Aether\lib\net35\Aether.dll</HintPath>
-          <Private>True</Private>
-          <Paket>True</Paket>
-        </Reference>
-      </ItemGroup>
-    </When>
-  </Choose>
-  <Choose>
-    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.5.1' Or $(TargetFrameworkVersion) == 'v4.5.2' Or $(TargetFrameworkVersion) == 'v4.5.3' Or $(TargetFrameworkVersion) == 'v4.6' Or $(TargetFrameworkVersion) == 'v4.6.1' Or $(TargetFrameworkVersion) == 'v4.6.2' Or $(TargetFrameworkVersion) == 'v4.6.3')">
-      <ItemGroup>
-        <Reference Include="Chiron">
-          <HintPath>..\..\packages\Chiron\lib\net40\Chiron.dll</HintPath>
-          <Private>True</Private>
-          <Paket>True</Paket>
-        </Reference>
-      </ItemGroup>
-    </When>
-  </Choose>
-  <Choose>
-    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.5.1' Or $(TargetFrameworkVersion) == 'v4.5.2' Or $(TargetFrameworkVersion) == 'v4.5.3' Or $(TargetFrameworkVersion) == 'v4.6' Or $(TargetFrameworkVersion) == 'v4.6.1' Or $(TargetFrameworkVersion) == 'v4.6.2' Or $(TargetFrameworkVersion) == 'v4.6.3')">
-      <ItemGroup>
-        <Reference Include="FParsec">
-          <HintPath>..\..\packages\FParsec\lib\net40-client\FParsec.dll</HintPath>
-          <Private>True</Private>
-          <Paket>True</Paket>
-        </Reference>
-        <Reference Include="FParsecCS">
-          <HintPath>..\..\packages\FParsec\lib\net40-client\FParsecCS.dll</HintPath>
-          <Private>True</Private>
-          <Paket>True</Paket>
-        </Reference>
-      </ItemGroup>
-    </When>
-  </Choose>
-  <Choose>
-    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.5.1' Or $(TargetFrameworkVersion) == 'v4.5.2' Or $(TargetFrameworkVersion) == 'v4.5.3' Or $(TargetFrameworkVersion) == 'v4.6' Or $(TargetFrameworkVersion) == 'v4.6.1' Or $(TargetFrameworkVersion) == 'v4.6.2' Or $(TargetFrameworkVersion) == 'v4.6.3')">
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.5.1' Or $(TargetFrameworkVersion) == 'v4.5.2' Or $(TargetFrameworkVersion) == 'v4.5.3' Or $(TargetFrameworkVersion) == 'v4.6' Or $(TargetFrameworkVersion) == 'v4.6.1' Or $(TargetFrameworkVersion) == 'v4.6.2' Or $(TargetFrameworkVersion) == 'v4.6.3' Or $(TargetFrameworkVersion) == 'v4.7' Or $(TargetFrameworkVersion) == 'v4.7.1')">
       <ItemGroup>
         <Reference Include="FSharp.Core">
           <HintPath>..\..\packages\FSharp.Core\lib\net45\FSharp.Core.dll</HintPath>
@@ -127,7 +95,127 @@
     </When>
   </Choose>
   <Choose>
-    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.5.1' Or $(TargetFrameworkVersion) == 'v4.5.2' Or $(TargetFrameworkVersion) == 'v4.5.3' Or $(TargetFrameworkVersion) == 'v4.6' Or $(TargetFrameworkVersion) == 'v4.6.1' Or $(TargetFrameworkVersion) == 'v4.6.2' Or $(TargetFrameworkVersion) == 'v4.6.3')">
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.6' Or $(TargetFrameworkVersion) == 'v4.6.1' Or $(TargetFrameworkVersion) == 'v4.6.2' Or $(TargetFrameworkVersion) == 'v4.6.3' Or $(TargetFrameworkVersion) == 'v4.7' Or $(TargetFrameworkVersion) == 'v4.7.1')">
+      <ItemGroup>
+        <Reference Include="System.Console">
+          <HintPath>..\..\packages\System.Console\lib\net46\System.Console.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Choose>
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.6.2' Or $(TargetFrameworkVersion) == 'v4.6.3' Or $(TargetFrameworkVersion) == 'v4.7' Or $(TargetFrameworkVersion) == 'v4.7.1')">
+      <ItemGroup>
+        <Reference Include="System.IO">
+          <HintPath>..\..\packages\System.IO\lib\net462\System.IO.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Choose>
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.6.3' Or $(TargetFrameworkVersion) == 'v4.7' Or $(TargetFrameworkVersion) == 'v4.7.1')">
+      <ItemGroup>
+        <Reference Include="System.Linq">
+          <HintPath>..\..\packages\System.Linq\lib\net463\System.Linq.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Choose>
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.6.3' Or $(TargetFrameworkVersion) == 'v4.7' Or $(TargetFrameworkVersion) == 'v4.7.1')">
+      <ItemGroup>
+        <Reference Include="System.Linq.Expressions">
+          <HintPath>..\..\packages\System.Linq.Expressions\lib\net463\System.Linq.Expressions.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Choose>
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.6.2' Or $(TargetFrameworkVersion) == 'v4.6.3' Or $(TargetFrameworkVersion) == 'v4.7' Or $(TargetFrameworkVersion) == 'v4.7.1')">
+      <ItemGroup>
+        <Reference Include="System.Reflection">
+          <HintPath>..\..\packages\System.Reflection\lib\net462\System.Reflection.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Choose>
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.6' Or $(TargetFrameworkVersion) == 'v4.6.1')">
+      <ItemGroup>
+        <Reference Include="System.ComponentModel.Composition">
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.6.2' Or $(TargetFrameworkVersion) == 'v4.6.3' Or $(TargetFrameworkVersion) == 'v4.7' Or $(TargetFrameworkVersion) == 'v4.7.1')">
+      <ItemGroup>
+        <Reference Include="System.ComponentModel.Composition">
+          <Paket>True</Paket>
+        </Reference>
+        <Reference Include="System.Runtime">
+          <HintPath>..\..\packages\System.Runtime\lib\net462\System.Runtime.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Choose>
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.6.2' Or $(TargetFrameworkVersion) == 'v4.6.3' Or $(TargetFrameworkVersion) == 'v4.7' Or $(TargetFrameworkVersion) == 'v4.7.1')">
+      <ItemGroup>
+        <Reference Include="System.Runtime.Extensions">
+          <HintPath>..\..\packages\System.Runtime.Extensions\lib\net462\System.Runtime.Extensions.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Choose>
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.6.3' Or $(TargetFrameworkVersion) == 'v4.7' Or $(TargetFrameworkVersion) == 'v4.7.1')">
+      <ItemGroup>
+        <Reference Include="System.Text.RegularExpressions">
+          <HintPath>..\..\packages\System.Text.RegularExpressions\lib\net463\System.Text.RegularExpressions.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Choose>
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.6' Or $(TargetFrameworkVersion) == 'v4.6.1' Or $(TargetFrameworkVersion) == 'v4.6.2' Or $(TargetFrameworkVersion) == 'v4.6.3' Or $(TargetFrameworkVersion) == 'v4.7' Or $(TargetFrameworkVersion) == 'v4.7.1')">
+      <ItemGroup>
+        <Reference Include="System.Threading.Thread">
+          <HintPath>..\..\packages\System.Threading.Thread\lib\net46\System.Threading.Thread.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Choose>
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And $(TargetFrameworkVersion) == 'v4.7.1'">
+      <ItemGroup>
+        <Reference Include="System.Threading.ThreadPool">
+          <HintPath>..\..\packages\System.Threading.ThreadPool\lib\net46\System.Threading.ThreadPool.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Choose>
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.5.1' Or $(TargetFrameworkVersion) == 'v4.5.2' Or $(TargetFrameworkVersion) == 'v4.5.3' Or $(TargetFrameworkVersion) == 'v4.6' Or $(TargetFrameworkVersion) == 'v4.6.1' Or $(TargetFrameworkVersion) == 'v4.6.2' Or $(TargetFrameworkVersion) == 'v4.6.3' Or $(TargetFrameworkVersion) == 'v4.7' Or $(TargetFrameworkVersion) == 'v4.7.1')">
       <ItemGroup>
         <Reference Include="System.ValueTuple">
           <HintPath>..\..\packages\System.ValueTuple\lib\netstandard1.0\System.ValueTuple.dll</HintPath>

--- a/src/SynVer.Lib/paket.references
+++ b/src/SynVer.Lib/paket.references
@@ -1,2 +1,2 @@
 FSharp.Core
-Chiron
+File:SExpression.fs

--- a/src/SynVer/Program.fs
+++ b/src/SynVer/Program.fs
@@ -15,15 +15,15 @@ with
     interface IArgParserTemplate with
         member s.Usage =
             match s with
-            | Surface_of _ -> "Get the public api surface of the .net binary as json"
+            | Surface_of _ -> "Get the public api surface of the .net binary as lson"
             | Magnitude _-> "Get the magnitude of the difference between two .net binaries"
             | Output _-> "Send output to file"
             | Diff _ -> "Get the difference between two .net binaries"
             | Bump _ -> "Get the next version based on the difference between two .net binaries"
 
-let (|AssemblyFile|JsonFile|Other|) (maybeFile:string) =
+let (|AssemblyFile|LsonFile|Other|) (maybeFile:string) =
   match maybeFile, File.Exists(maybeFile) with
-  | f, true when f.EndsWith(".json") -> JsonFile
+  | f, true when f.EndsWith(".lson") -> LsonFile
   | f, true when f.EndsWith(".dll") -> AssemblyFile
   | f, _  -> Other
 
@@ -38,7 +38,7 @@ let loadAssembly f =
 
 let getSurfaceAreaOf (f:string): Result<Package,string>=
   match f with
-  | JsonFile ->
+  | LsonFile ->
     let res = File.ReadAllText f
               |> Lson.tryDeserialize
     match res with
@@ -47,7 +47,7 @@ let getSurfaceAreaOf (f:string): Result<Package,string>=
   | AssemblyFile -> 
         loadAssembly f
         |> Result.map SurfaceArea.ofAssembly
-  | Other -> Error "No dll or json specified"
+  | Other -> Error "No dll or lson specified"
 
 
 let getDiff released modified : Result<string,string>=

--- a/src/SynVer/Program.fs
+++ b/src/SynVer/Program.fs
@@ -4,7 +4,6 @@ open Argu
 open SynVer
 open System.Reflection
 open System.IO
-open Chiron
 
 type CLIArguments =
     | Surface_of of path:string
@@ -31,72 +30,70 @@ let (|AssemblyFile|JsonFile|Other|) (maybeFile:string) =
 let loadAssembly f =
   try
     Assembly.LoadFile (Path.GetFullPath f)
-    |> Choice1Of2
+    |> Ok
   with ex ->
     (sprintf "Failed to load assembly %s due to %s\n%s" f ex.Message ex.StackTrace) 
-    |> Choice2Of2
-    
-let mapFirst f= function
-                | Choice1Of2 a -> Choice1Of2 (f a)
-                | Choice2Of2 err -> Choice2Of2 err
+    |> Error
 
-let getSurfaceAreaOf (f:string): Choice<Package,string>=
+
+let getSurfaceAreaOf (f:string): Result<Package,string>=
   match f with
   | JsonFile ->
-              File.ReadAllText f
-              |> Json.parse
-              |> Json.tryDeserialize
-
+    let res = File.ReadAllText f
+              |> Lson.tryDeserialize
+    match res with
+    | Some p -> Ok p
+    | None -> Error "Couldn't deserialize"
   | AssemblyFile -> 
         loadAssembly f
-            |> mapFirst SurfaceArea.ofAssembly
-  | Other -> Choice2Of2 "No dll or json specified"
+        |> Result.map SurfaceArea.ofAssembly
+  | Other -> Error "No dll or json specified"
 
 
-let getDiff released modified : Choice<string,string>=
+let getDiff released modified : Result<string,string>=
     let maybeReleased,maybeModified= getSurfaceAreaOf released, getSurfaceAreaOf modified
     match maybeReleased,maybeModified with
-    | Choice1Of2 released, Choice1Of2 modified ->
+    | Ok released, Ok modified ->
         let changes =  SurfaceArea.diff released modified
         String.Join(Environment.NewLine, changes)
-        |> Choice1Of2
+        |> Ok
     | _, _ ->
         let errors = 
             [maybeReleased;maybeModified] 
-            |> List.choose (function Choice2Of2 e-> Some e | _ -> None)
+            |> List.choose (function Error e-> Some e | _ -> None)
             |> List.toArray
         
-        Choice2Of2 (String.Join(Environment.NewLine, errors) )
+        Error (String.Join(Environment.NewLine, errors) )
 
-let getBump version released modified : Choice<string*Version,string>=
+let getBump version released modified : Result<string*Version,string>=
     let maybeReleased,maybeModified= getSurfaceAreaOf released, getSurfaceAreaOf modified
     match maybeReleased,maybeModified with
-    | Choice1Of2 released, Choice1Of2 modified ->
+    | Ok released, Ok modified ->
         SurfaceArea.bump version released modified
-        |> Choice1Of2
+        |> Ok
     | _, _ ->
         let errors = 
             [maybeReleased;maybeModified] 
-            |> List.choose (function Choice2Of2 err-> Some err | _ -> None)
+            |> List.choose (function Error err-> Some err | _ -> None)
             |> List.toArray
         
-        Choice2Of2 (String.Join(Environment.NewLine, errors) )
+        Error (String.Join(Environment.NewLine, errors) )
 
 [<EntryPoint>]
 let main argv = 
     let parser = ArgumentParser.Create<CLIArguments>(programName = "synver.exe")
 
     let results = parser.Parse argv
-    let writeResult (res:Choice<string,string>)=
+    let writeResult (res:Result<string,string>)=
         match res with
-        | Choice1Of2 msg-> Console.WriteLine msg ; 0
-        | Choice2Of2 msg->Console.Error.WriteLine msg ; 1
+        | Ok msg-> Console.WriteLine msg ; 0
+        | Error msg->Console.Error.WriteLine msg ; 1
 
     let all = results.GetAllResults()
     if List.isEmpty all then
-        Choice2Of2(parser.PrintUsage())
+        Error(parser.PrintUsage())
     elif results.IsUsageRequested then
-        Choice1Of2(parser.PrintUsage())
+        Ok(parser.PrintUsage())
     else
         let maybeFile = results.TryGetResult(<@ Surface_of @>)
         let maybeDiff = results.TryGetResult(<@ Diff @>)
@@ -107,28 +104,27 @@ let main argv =
         match maybeFile, maybeDiff, maybeMagnitude, maybeBump with
         | Some file, None, None, None ->
             loadAssembly file
-            |> mapFirst (
+            |> Result.map (
                 SurfaceArea.ofAssembly 
-                >> Json.serialize
-                >>(Json.formatWith JsonFormattingOptions.Pretty)
+                >> Lson.serialize
             )
         | None, Some (released, modified), None, None ->
             getDiff released modified
         | None, None, Some (released,modified), None ->
             getBump "0.0.0" released modified
             |> function 
-                | Choice1Of2 (_,version)->version.ToString() |>Choice1Of2
-                | Choice2Of2 a->Choice2Of2 a
+                | Ok (_,version)->version.ToString() |>Ok
+                | Error a->Error a
         | None, None, None, Some (version,released,modified) ->
             getBump version released modified
             |> function 
-                | Choice1Of2 (version,_)->version |>Choice1Of2
-                | Choice2Of2 a->Choice2Of2 a
+                | Ok (version,_)->version |>Ok
+                | Error a->Error a
         | _,_,_,_ ->
-            Choice2Of2(parser.PrintUsage())
+            Error(parser.PrintUsage())
         |> (fun res-> 
             match res, maybeOutput with
-            | Choice1Of2 content, Some output-> 
+            | Ok content, Some output-> 
                 File.WriteAllText(output, content)
                 res
             | _ -> res

--- a/src/SynVer/SynVer.fsproj
+++ b/src/SynVer/SynVer.fsproj
@@ -1,6 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
-
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -71,7 +71,7 @@
     </ProjectReference>
   </ItemGroup>
   <Choose>
-    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.5.1' Or $(TargetFrameworkVersion) == 'v4.5.2' Or $(TargetFrameworkVersion) == 'v4.5.3' Or $(TargetFrameworkVersion) == 'v4.6' Or $(TargetFrameworkVersion) == 'v4.6.1' Or $(TargetFrameworkVersion) == 'v4.6.2' Or $(TargetFrameworkVersion) == 'v4.6.3')">
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.5.1' Or $(TargetFrameworkVersion) == 'v4.5.2' Or $(TargetFrameworkVersion) == 'v4.5.3' Or $(TargetFrameworkVersion) == 'v4.6' Or $(TargetFrameworkVersion) == 'v4.6.1' Or $(TargetFrameworkVersion) == 'v4.6.2' Or $(TargetFrameworkVersion) == 'v4.6.3' Or $(TargetFrameworkVersion) == 'v4.7' Or $(TargetFrameworkVersion) == 'v4.7.1')">
       <ItemGroup>
         <Reference Include="Aether">
           <HintPath>..\..\packages\Aether\lib\net35\Aether.dll</HintPath>
@@ -82,7 +82,7 @@
     </When>
   </Choose>
   <Choose>
-    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.5.1' Or $(TargetFrameworkVersion) == 'v4.5.2' Or $(TargetFrameworkVersion) == 'v4.5.3' Or $(TargetFrameworkVersion) == 'v4.6' Or $(TargetFrameworkVersion) == 'v4.6.1' Or $(TargetFrameworkVersion) == 'v4.6.2' Or $(TargetFrameworkVersion) == 'v4.6.3')">
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.5.1' Or $(TargetFrameworkVersion) == 'v4.5.2' Or $(TargetFrameworkVersion) == 'v4.5.3' Or $(TargetFrameworkVersion) == 'v4.6' Or $(TargetFrameworkVersion) == 'v4.6.1' Or $(TargetFrameworkVersion) == 'v4.6.2' Or $(TargetFrameworkVersion) == 'v4.6.3' Or $(TargetFrameworkVersion) == 'v4.7' Or $(TargetFrameworkVersion) == 'v4.7.1')">
       <ItemGroup>
         <Reference Include="Argu">
           <HintPath>..\..\packages\Argu\lib\net40\Argu.dll</HintPath>
@@ -93,7 +93,7 @@
     </When>
   </Choose>
   <Choose>
-    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.5.1' Or $(TargetFrameworkVersion) == 'v4.5.2' Or $(TargetFrameworkVersion) == 'v4.5.3' Or $(TargetFrameworkVersion) == 'v4.6' Or $(TargetFrameworkVersion) == 'v4.6.1' Or $(TargetFrameworkVersion) == 'v4.6.2' Or $(TargetFrameworkVersion) == 'v4.6.3')">
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.5.1' Or $(TargetFrameworkVersion) == 'v4.5.2' Or $(TargetFrameworkVersion) == 'v4.5.3' Or $(TargetFrameworkVersion) == 'v4.6' Or $(TargetFrameworkVersion) == 'v4.6.1' Or $(TargetFrameworkVersion) == 'v4.6.2' Or $(TargetFrameworkVersion) == 'v4.6.3' Or $(TargetFrameworkVersion) == 'v4.7' Or $(TargetFrameworkVersion) == 'v4.7.1')">
       <ItemGroup>
         <Reference Include="Chiron">
           <HintPath>..\..\packages\Chiron\lib\net40\Chiron.dll</HintPath>
@@ -104,7 +104,7 @@
     </When>
   </Choose>
   <Choose>
-    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.5.1' Or $(TargetFrameworkVersion) == 'v4.5.2' Or $(TargetFrameworkVersion) == 'v4.5.3' Or $(TargetFrameworkVersion) == 'v4.6' Or $(TargetFrameworkVersion) == 'v4.6.1' Or $(TargetFrameworkVersion) == 'v4.6.2' Or $(TargetFrameworkVersion) == 'v4.6.3')">
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.5.1' Or $(TargetFrameworkVersion) == 'v4.5.2' Or $(TargetFrameworkVersion) == 'v4.5.3' Or $(TargetFrameworkVersion) == 'v4.6' Or $(TargetFrameworkVersion) == 'v4.6.1' Or $(TargetFrameworkVersion) == 'v4.6.2' Or $(TargetFrameworkVersion) == 'v4.6.3' Or $(TargetFrameworkVersion) == 'v4.7' Or $(TargetFrameworkVersion) == 'v4.7.1')">
       <ItemGroup>
         <Reference Include="FParsec">
           <HintPath>..\..\packages\FParsec\lib\net40-client\FParsec.dll</HintPath>
@@ -120,7 +120,7 @@
     </When>
   </Choose>
   <Choose>
-    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.5.1' Or $(TargetFrameworkVersion) == 'v4.5.2' Or $(TargetFrameworkVersion) == 'v4.5.3' Or $(TargetFrameworkVersion) == 'v4.6' Or $(TargetFrameworkVersion) == 'v4.6.1' Or $(TargetFrameworkVersion) == 'v4.6.2' Or $(TargetFrameworkVersion) == 'v4.6.3')">
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.5.1' Or $(TargetFrameworkVersion) == 'v4.5.2' Or $(TargetFrameworkVersion) == 'v4.5.3' Or $(TargetFrameworkVersion) == 'v4.6' Or $(TargetFrameworkVersion) == 'v4.6.1' Or $(TargetFrameworkVersion) == 'v4.6.2' Or $(TargetFrameworkVersion) == 'v4.6.3' Or $(TargetFrameworkVersion) == 'v4.7' Or $(TargetFrameworkVersion) == 'v4.7.1')">
       <ItemGroup>
         <Reference Include="FSharp.Core">
           <HintPath>..\..\packages\FSharp.Core\lib\net45\FSharp.Core.dll</HintPath>
@@ -131,7 +131,7 @@
     </When>
   </Choose>
   <Choose>
-    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And $(TargetFrameworkVersion) == 'v4.6.3'">
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.6' Or $(TargetFrameworkVersion) == 'v4.6.1' Or $(TargetFrameworkVersion) == 'v4.6.2' Or $(TargetFrameworkVersion) == 'v4.6.3' Or $(TargetFrameworkVersion) == 'v4.7' Or $(TargetFrameworkVersion) == 'v4.7.1')">
       <ItemGroup>
         <Reference Include="Microsoft.Win32.Primitives">
           <HintPath>..\..\packages\Microsoft.Win32.Primitives\lib\net46\Microsoft.Win32.Primitives.dll</HintPath>
@@ -142,7 +142,16 @@
     </When>
   </Choose>
   <Choose>
-    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And $(TargetFrameworkVersion) == 'v4.6.3'">
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.6' Or $(TargetFrameworkVersion) == 'v4.6.1' Or $(TargetFrameworkVersion) == 'v4.6.2')">
+      <ItemGroup>
+        <Reference Include="System.AppContext">
+          <HintPath>..\..\packages\System.AppContext\lib\net46\System.AppContext.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.6.3' Or $(TargetFrameworkVersion) == 'v4.7' Or $(TargetFrameworkVersion) == 'v4.7.1')">
       <ItemGroup>
         <Reference Include="System.AppContext">
           <HintPath>..\..\packages\System.AppContext\lib\net463\System.AppContext.dll</HintPath>
@@ -153,7 +162,7 @@
     </When>
   </Choose>
   <Choose>
-    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And $(TargetFrameworkVersion) == 'v4.6.3'">
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.6' Or $(TargetFrameworkVersion) == 'v4.6.1' Or $(TargetFrameworkVersion) == 'v4.6.2' Or $(TargetFrameworkVersion) == 'v4.6.3' Or $(TargetFrameworkVersion) == 'v4.7' Or $(TargetFrameworkVersion) == 'v4.7.1')">
       <ItemGroup>
         <Reference Include="System.Console">
           <HintPath>..\..\packages\System.Console\lib\net46\System.Console.dll</HintPath>
@@ -164,7 +173,7 @@
     </When>
   </Choose>
   <Choose>
-    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And $(TargetFrameworkVersion) == 'v4.6.3'">
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.6.2' Or $(TargetFrameworkVersion) == 'v4.6.3' Or $(TargetFrameworkVersion) == 'v4.7' Or $(TargetFrameworkVersion) == 'v4.7.1')">
       <ItemGroup>
         <Reference Include="System.Diagnostics.Tracing">
           <HintPath>..\..\packages\System.Diagnostics.Tracing\lib\net462\System.Diagnostics.Tracing.dll</HintPath>
@@ -175,7 +184,7 @@
     </When>
   </Choose>
   <Choose>
-    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And $(TargetFrameworkVersion) == 'v4.6.3'">
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.6' Or $(TargetFrameworkVersion) == 'v4.6.1' Or $(TargetFrameworkVersion) == 'v4.6.2' Or $(TargetFrameworkVersion) == 'v4.6.3' Or $(TargetFrameworkVersion) == 'v4.7' Or $(TargetFrameworkVersion) == 'v4.7.1')">
       <ItemGroup>
         <Reference Include="System.Globalization.Calendars">
           <HintPath>..\..\packages\System.Globalization.Calendars\lib\net46\System.Globalization.Calendars.dll</HintPath>
@@ -186,7 +195,7 @@
     </When>
   </Choose>
   <Choose>
-    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And $(TargetFrameworkVersion) == 'v4.6.3'">
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.6.2' Or $(TargetFrameworkVersion) == 'v4.6.3' Or $(TargetFrameworkVersion) == 'v4.7' Or $(TargetFrameworkVersion) == 'v4.7.1')">
       <ItemGroup>
         <Reference Include="System.IO">
           <HintPath>..\..\packages\System.IO\lib\net462\System.IO.dll</HintPath>
@@ -197,7 +206,7 @@
     </When>
   </Choose>
   <Choose>
-    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And $(TargetFrameworkVersion) == 'v4.6.3'">
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.6' Or $(TargetFrameworkVersion) == 'v4.6.1' Or $(TargetFrameworkVersion) == 'v4.6.2' Or $(TargetFrameworkVersion) == 'v4.6.3' Or $(TargetFrameworkVersion) == 'v4.7' Or $(TargetFrameworkVersion) == 'v4.7.1')">
       <ItemGroup>
         <Reference Include="System.IO.Compression">
           <HintPath>..\..\packages\System.IO.Compression\lib\net46\System.IO.Compression.dll</HintPath>
@@ -208,7 +217,7 @@
     </When>
   </Choose>
   <Choose>
-    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And $(TargetFrameworkVersion) == 'v4.6.3'">
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.6' Or $(TargetFrameworkVersion) == 'v4.6.1' Or $(TargetFrameworkVersion) == 'v4.6.2' Or $(TargetFrameworkVersion) == 'v4.6.3' Or $(TargetFrameworkVersion) == 'v4.7' Or $(TargetFrameworkVersion) == 'v4.7.1')">
       <ItemGroup>
         <Reference Include="System.IO.Compression.FileSystem">
           <Paket>True</Paket>
@@ -222,7 +231,7 @@
     </When>
   </Choose>
   <Choose>
-    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And $(TargetFrameworkVersion) == 'v4.6.3'">
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.6' Or $(TargetFrameworkVersion) == 'v4.6.1' Or $(TargetFrameworkVersion) == 'v4.6.2' Or $(TargetFrameworkVersion) == 'v4.6.3' Or $(TargetFrameworkVersion) == 'v4.7' Or $(TargetFrameworkVersion) == 'v4.7.1')">
       <ItemGroup>
         <Reference Include="System.IO.FileSystem">
           <HintPath>..\..\packages\System.IO.FileSystem\lib\net46\System.IO.FileSystem.dll</HintPath>
@@ -233,7 +242,7 @@
     </When>
   </Choose>
   <Choose>
-    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.6' Or $(TargetFrameworkVersion) == 'v4.6.1' Or $(TargetFrameworkVersion) == 'v4.6.2' Or $(TargetFrameworkVersion) == 'v4.6.3')">
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.6' Or $(TargetFrameworkVersion) == 'v4.6.1' Or $(TargetFrameworkVersion) == 'v4.6.2' Or $(TargetFrameworkVersion) == 'v4.6.3' Or $(TargetFrameworkVersion) == 'v4.7' Or $(TargetFrameworkVersion) == 'v4.7.1')">
       <ItemGroup>
         <Reference Include="System.IO.FileSystem.Primitives">
           <HintPath>..\..\packages\System.IO.FileSystem.Primitives\lib\net46\System.IO.FileSystem.Primitives.dll</HintPath>
@@ -244,7 +253,29 @@
     </When>
   </Choose>
   <Choose>
-    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And $(TargetFrameworkVersion) == 'v4.6.3'">
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.6.3' Or $(TargetFrameworkVersion) == 'v4.7' Or $(TargetFrameworkVersion) == 'v4.7.1')">
+      <ItemGroup>
+        <Reference Include="System.Linq">
+          <HintPath>..\..\packages\System.Linq\lib\net463\System.Linq.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Choose>
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.6.3' Or $(TargetFrameworkVersion) == 'v4.7' Or $(TargetFrameworkVersion) == 'v4.7.1')">
+      <ItemGroup>
+        <Reference Include="System.Linq.Expressions">
+          <HintPath>..\..\packages\System.Linq.Expressions\lib\net463\System.Linq.Expressions.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Choose>
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.6' Or $(TargetFrameworkVersion) == 'v4.6.1' Or $(TargetFrameworkVersion) == 'v4.6.2' Or $(TargetFrameworkVersion) == 'v4.6.3' Or $(TargetFrameworkVersion) == 'v4.7' Or $(TargetFrameworkVersion) == 'v4.7.1')">
       <ItemGroup>
         <Reference Include="System.Net.Http">
           <HintPath>..\..\packages\System.Net.Http\lib\net46\System.Net.Http.dll</HintPath>
@@ -255,7 +286,7 @@
     </When>
   </Choose>
   <Choose>
-    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And $(TargetFrameworkVersion) == 'v4.6.3'">
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.6' Or $(TargetFrameworkVersion) == 'v4.6.1' Or $(TargetFrameworkVersion) == 'v4.6.2' Or $(TargetFrameworkVersion) == 'v4.6.3' Or $(TargetFrameworkVersion) == 'v4.7' Or $(TargetFrameworkVersion) == 'v4.7.1')">
       <ItemGroup>
         <Reference Include="System.Net.Sockets">
           <HintPath>..\..\packages\System.Net.Sockets\lib\net46\System.Net.Sockets.dll</HintPath>
@@ -266,14 +297,25 @@
     </When>
   </Choose>
   <Choose>
-    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.5.1' Or $(TargetFrameworkVersion) == 'v4.5.2' Or $(TargetFrameworkVersion) == 'v4.5.3' Or $(TargetFrameworkVersion) == 'v4.6' Or $(TargetFrameworkVersion) == 'v4.6.1')">
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.6.2' Or $(TargetFrameworkVersion) == 'v4.6.3' Or $(TargetFrameworkVersion) == 'v4.7' Or $(TargetFrameworkVersion) == 'v4.7.1')">
+      <ItemGroup>
+        <Reference Include="System.Reflection">
+          <HintPath>..\..\packages\System.Reflection\lib\net462\System.Reflection.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Choose>
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.6' Or $(TargetFrameworkVersion) == 'v4.6.1')">
       <ItemGroup>
         <Reference Include="System.ComponentModel.Composition">
           <Paket>True</Paket>
         </Reference>
       </ItemGroup>
     </When>
-    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.6.2' Or $(TargetFrameworkVersion) == 'v4.6.3')">
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.6.2' Or $(TargetFrameworkVersion) == 'v4.6.3' Or $(TargetFrameworkVersion) == 'v4.7' Or $(TargetFrameworkVersion) == 'v4.7.1')">
       <ItemGroup>
         <Reference Include="System.ComponentModel.Composition">
           <Paket>True</Paket>
@@ -287,7 +329,27 @@
     </When>
   </Choose>
   <Choose>
-    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And $(TargetFrameworkVersion) == 'v4.6.3'">
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.6.2' Or $(TargetFrameworkVersion) == 'v4.6.3' Or $(TargetFrameworkVersion) == 'v4.7' Or $(TargetFrameworkVersion) == 'v4.7.1')">
+      <ItemGroup>
+        <Reference Include="System.Runtime.Extensions">
+          <HintPath>..\..\packages\System.Runtime.Extensions\lib\net462\System.Runtime.Extensions.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Choose>
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And $(TargetFrameworkVersion) == 'v4.6.2'">
+      <ItemGroup>
+        <Reference Include="System.Runtime.InteropServices">
+          <HintPath>..\..\packages\System.Runtime.InteropServices\lib\net462\System.Runtime.InteropServices.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.6.3' Or $(TargetFrameworkVersion) == 'v4.7' Or $(TargetFrameworkVersion) == 'v4.7.1')">
       <ItemGroup>
         <Reference Include="System.Runtime.InteropServices">
           <HintPath>..\..\packages\System.Runtime.InteropServices\lib\net463\System.Runtime.InteropServices.dll</HintPath>
@@ -298,7 +360,7 @@
     </When>
   </Choose>
   <Choose>
-    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And $(TargetFrameworkVersion) == 'v4.6.3'">
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.6' Or $(TargetFrameworkVersion) == 'v4.6.1' Or $(TargetFrameworkVersion) == 'v4.6.2' Or $(TargetFrameworkVersion) == 'v4.6.3' Or $(TargetFrameworkVersion) == 'v4.7' Or $(TargetFrameworkVersion) == 'v4.7.1')">
       <ItemGroup>
         <Reference Include="System.Runtime.InteropServices.RuntimeInformation">
           <HintPath>..\..\packages\System.Runtime.InteropServices.RuntimeInformation\lib\net45\System.Runtime.InteropServices.RuntimeInformation.dll</HintPath>
@@ -327,7 +389,7 @@
         </Reference>
       </ItemGroup>
     </When>
-    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And $(TargetFrameworkVersion) == 'v4.6.3'">
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.6.3' Or $(TargetFrameworkVersion) == 'v4.7' Or $(TargetFrameworkVersion) == 'v4.7.1')">
       <ItemGroup>
         <Reference Include="System.Security.Cryptography.Algorithms">
           <HintPath>..\..\packages\System.Security.Cryptography.Algorithms\lib\net463\System.Security.Cryptography.Algorithms.dll</HintPath>
@@ -338,7 +400,7 @@
     </When>
   </Choose>
   <Choose>
-    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.6' Or $(TargetFrameworkVersion) == 'v4.6.1' Or $(TargetFrameworkVersion) == 'v4.6.2' Or $(TargetFrameworkVersion) == 'v4.6.3')">
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.6' Or $(TargetFrameworkVersion) == 'v4.6.1' Or $(TargetFrameworkVersion) == 'v4.6.2' Or $(TargetFrameworkVersion) == 'v4.6.3' Or $(TargetFrameworkVersion) == 'v4.7' Or $(TargetFrameworkVersion) == 'v4.7.1')">
       <ItemGroup>
         <Reference Include="System.Security.Cryptography.Encoding">
           <HintPath>..\..\packages\System.Security.Cryptography.Encoding\lib\net46\System.Security.Cryptography.Encoding.dll</HintPath>
@@ -349,7 +411,7 @@
     </When>
   </Choose>
   <Choose>
-    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.6' Or $(TargetFrameworkVersion) == 'v4.6.1' Or $(TargetFrameworkVersion) == 'v4.6.2' Or $(TargetFrameworkVersion) == 'v4.6.3')">
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.6' Or $(TargetFrameworkVersion) == 'v4.6.1' Or $(TargetFrameworkVersion) == 'v4.6.2' Or $(TargetFrameworkVersion) == 'v4.6.3' Or $(TargetFrameworkVersion) == 'v4.7' Or $(TargetFrameworkVersion) == 'v4.7.1')">
       <ItemGroup>
         <Reference Include="System.Security.Cryptography.Primitives">
           <HintPath>..\..\packages\System.Security.Cryptography.Primitives\lib\net46\System.Security.Cryptography.Primitives.dll</HintPath>
@@ -369,7 +431,7 @@
         </Reference>
       </ItemGroup>
     </When>
-    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.6.1' Or $(TargetFrameworkVersion) == 'v4.6.2' Or $(TargetFrameworkVersion) == 'v4.6.3')">
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.6.1' Or $(TargetFrameworkVersion) == 'v4.6.2' Or $(TargetFrameworkVersion) == 'v4.6.3' Or $(TargetFrameworkVersion) == 'v4.7' Or $(TargetFrameworkVersion) == 'v4.7.1')">
       <ItemGroup>
         <Reference Include="System.Security.Cryptography.X509Certificates">
           <HintPath>..\..\packages\System.Security.Cryptography.X509Certificates\lib\net461\System.Security.Cryptography.X509Certificates.dll</HintPath>
@@ -380,7 +442,40 @@
     </When>
   </Choose>
   <Choose>
-    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.5.1' Or $(TargetFrameworkVersion) == 'v4.5.2' Or $(TargetFrameworkVersion) == 'v4.5.3' Or $(TargetFrameworkVersion) == 'v4.6' Or $(TargetFrameworkVersion) == 'v4.6.1' Or $(TargetFrameworkVersion) == 'v4.6.2' Or $(TargetFrameworkVersion) == 'v4.6.3')">
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.6.3' Or $(TargetFrameworkVersion) == 'v4.7' Or $(TargetFrameworkVersion) == 'v4.7.1')">
+      <ItemGroup>
+        <Reference Include="System.Text.RegularExpressions">
+          <HintPath>..\..\packages\System.Text.RegularExpressions\lib\net463\System.Text.RegularExpressions.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Choose>
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.6' Or $(TargetFrameworkVersion) == 'v4.6.1' Or $(TargetFrameworkVersion) == 'v4.6.2' Or $(TargetFrameworkVersion) == 'v4.6.3' Or $(TargetFrameworkVersion) == 'v4.7' Or $(TargetFrameworkVersion) == 'v4.7.1')">
+      <ItemGroup>
+        <Reference Include="System.Threading.Thread">
+          <HintPath>..\..\packages\System.Threading.Thread\lib\net46\System.Threading.Thread.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Choose>
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And $(TargetFrameworkVersion) == 'v4.7.1'">
+      <ItemGroup>
+        <Reference Include="System.Threading.ThreadPool">
+          <HintPath>..\..\packages\System.Threading.ThreadPool\lib\net46\System.Threading.ThreadPool.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Choose>
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.5.1' Or $(TargetFrameworkVersion) == 'v4.5.2' Or $(TargetFrameworkVersion) == 'v4.5.3' Or $(TargetFrameworkVersion) == 'v4.6' Or $(TargetFrameworkVersion) == 'v4.6.1' Or $(TargetFrameworkVersion) == 'v4.6.2' Or $(TargetFrameworkVersion) == 'v4.6.3' Or $(TargetFrameworkVersion) == 'v4.7' Or $(TargetFrameworkVersion) == 'v4.7.1')">
       <ItemGroup>
         <Reference Include="System.ValueTuple">
           <HintPath>..\..\packages\System.ValueTuple\lib\netstandard1.0\System.ValueTuple.dll</HintPath>
@@ -391,7 +486,21 @@
     </When>
   </Choose>
   <Choose>
-    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And $(TargetFrameworkVersion) == 'v4.6.3'">
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.6' Or $(TargetFrameworkVersion) == 'v4.6.1' Or $(TargetFrameworkVersion) == 'v4.6.2' Or $(TargetFrameworkVersion) == 'v4.6.3' Or $(TargetFrameworkVersion) == 'v4.7' Or $(TargetFrameworkVersion) == 'v4.7.1')">
+      <ItemGroup>
+        <Reference Include="System.Xml">
+          <Paket>True</Paket>
+        </Reference>
+        <Reference Include="System.Xml.ReaderWriter">
+          <HintPath>..\..\packages\System.Xml.ReaderWriter\lib\net46\System.Xml.ReaderWriter.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Choose>
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.6' Or $(TargetFrameworkVersion) == 'v4.6.1' Or $(TargetFrameworkVersion) == 'v4.6.2' Or $(TargetFrameworkVersion) == 'v4.6.3' Or $(TargetFrameworkVersion) == 'v4.7' Or $(TargetFrameworkVersion) == 'v4.7.1')">
       <ItemGroup>
         <Reference Include="System.Xml.Linq">
           <Paket>True</Paket>

--- a/tests/SynVer.Tests/NetTypeTests.fs
+++ b/tests/SynVer.Tests/NetTypeTests.fs
@@ -1,56 +1,52 @@
 module SynVer.NetTypeTests
 open SynVer
-open NUnit.Framework
+open Expecto
 open TestHelper.Types
+[<Tests>]
+let tests =
+  testList "Net Type" [
 
-[<Test>]
-let ``Tag net type NetType`` () =
-  let t = typeof<Version>
-  Assert.AreEqual(NetType.SumType, Reflect.tagNetType t)
-  let n = Version.Major
-  let nt = n.GetType()
-  Assert.AreEqual(NetType.SumType, Reflect.tagNetType nt)
-
-[<Test>]
-let ``Tag net type union`` () =
-  let t = typeof<Union>
-  Assert.AreEqual(NetType.SumType, Reflect.tagNetType t)
-
-[<Test>]
-let ``Tag net type union prime`` () =
-  let t = typeof<UnionWithParam>
-  Assert.AreEqual(NetType.SumType, Reflect.tagNetType t)
-  let foo=UnionWithParam.Foo (1,0.1)
-  let fooT =foo.GetType()
-  Assert.IsTrue(Reflect.isSumType fooT)
-
-[<Test>]
-let ``Tag net type union with names`` () =
-  let t = typeof<UnionWithParamNames>
-  Assert.AreEqual(NetType.SumType, Reflect.tagNetType t)
-  let foo = UnionWithParamNames.Foo(num=1,diff=0.1)
-  let fooT = foo.GetType()
-  Assert.IsTrue(Reflect.isSumType fooT)
-
-[<Test>]
-let ``Tag net type enum`` () =
-  let t = typeof<EnumType>
-  Assert.AreEqual(NetType.Enum, Reflect.tagNetType t)
-
-[<Test>]
-let ``Tag net type record`` () =
-  let t = typeof<RecordType>
-  Assert.AreEqual(NetType.RecordType, Reflect.tagNetType t)
-
-[<Test>]
-let ``Tag net type csharp struct`` ()=
-  Assert.AreEqual(NetType.Struct, Reflect.tagNetType CSharpStructType)
-
-[<Test>]
-let ``Tag net type fsharp struct`` ()=
-  let t = typeof<FsharpStruct>
-  Assert.AreEqual(NetType.Struct, Reflect.tagNetType t)
-
-[<Test>]
-let ``Tag net type module`` ()=
-  Assert.AreEqual(NetType.Module, Reflect.tagNetType ModuleT)
+    test "Tag net type NetType" {
+      let t = typeof<Version>
+      Expect.equal NetType.SumType (Reflect.tagNetType t) "sum type t"
+      let n = Version.Major
+      let nt = n.GetType()
+      Expect.equal NetType.SumType (Reflect.tagNetType nt) "sum type nt"
+    }
+    test "Tag net type union" {
+      let t = typeof<Union>
+      Expect.equal NetType.SumType (Reflect.tagNetType t) "sumtype union"
+    }
+    test "Tag net type union prime" {
+      let t = typeof<UnionWithParam>
+      Expect.equal NetType.SumType (Reflect.tagNetType t) "sumtype union prime"
+      let foo=UnionWithParam.Foo (1,0.1)
+      let fooT =foo.GetType()
+      Expect.isTrue (Reflect.isSumType fooT) "fooT"
+    }
+    test "Tag net type union with names" {
+      let t = typeof<UnionWithParamNames>
+      Expect.equal NetType.SumType (Reflect.tagNetType t) "sumtype with tag"
+      let foo = UnionWithParamNames.Foo(num=1,diff=0.1)
+      let fooT = foo.GetType()
+      Expect.isTrue (Reflect.isSumType fooT) "is sumtype"
+    }
+    test "Tag net type enum" {
+      let t = typeof<EnumType>
+      Expect.equal NetType.Enum (Reflect.tagNetType t) "enum type"
+    }
+    test "Tag net type record" {
+      let t = typeof<RecordType>
+      Expect.equal NetType.RecordType (Reflect.tagNetType t) "record type"
+    }
+    test "Tag net type csharp struct"{
+      Expect.equal NetType.Struct (Reflect.tagNetType CSharpStructType) "struct type"
+    }
+    test "Tag net type fsharp struct"{
+      let t = typeof<FsharpStruct>
+      Expect.equal NetType.Struct (Reflect.tagNetType t) "struct type"
+    }
+    test "Tag net type module"{
+      Expect.equal NetType.Module (Reflect.tagNetType ModuleT) "module"
+    }
+  ]

--- a/tests/SynVer.Tests/Program.fs
+++ b/tests/SynVer.Tests/Program.fs
@@ -1,0 +1,7 @@
+module Main
+
+open Expecto
+
+[<EntryPoint>]
+let main args =
+  runTestsInAssembly defaultConfig args

--- a/tests/SynVer.Tests/SerializationTests.fs
+++ b/tests/SynVer.Tests/SerializationTests.fs
@@ -1,43 +1,45 @@
 module SynVer.SerializationTests
 open SynVer
-open NUnit.Framework
+open Expecto
 open TestHelper
-open Chiron
 
 let assertCanSerializeAndDeserialize assembly
   =
     let surface = SurfaceArea.ofAssembly assembly
     let deserialized 
         = surface
-          |> Json.serialize
-          |> Json.deserialize
-    let same = deserialized = surface
-    Assert.IsTrue(same)
-[<Test>]
-let ``csharp`` () =
-  assertCanSerializeAndDeserialize csharp
-[<Test>]
-let ``csharp2`` () =
-  assertCanSerializeAndDeserialize csharp2
-[<Test>]
-let ``enum`` () =
-  assertCanSerializeAndDeserialize enum
-[<Test>]
-let ``enum2`` () =
-  assertCanSerializeAndDeserialize enum2
-[<Test>]
-let ``enum3`` () =
-  assertCanSerializeAndDeserialize enum3
-[<Test>]
-let ``fsharp`` () =
-  assertCanSerializeAndDeserialize fsharp
-[<Test>]
-let ``fsharp2`` () =
-  assertCanSerializeAndDeserialize fsharp2
-[<Test>]
-let ``argu`` () =
-  assertCanSerializeAndDeserialize arguAssembly
-[<Test>]
-let ``chiron`` () =
-  assertCanSerializeAndDeserialize chironAssembly
+          |> Lson.serialize
+          |> Lson.deserialize
+    Expect.equal surface deserialized (assembly.ToString())
+[<Tests>]
+let tests =
+  testList "Serialization tests" [    
+    test "csharp" {
+      assertCanSerializeAndDeserialize csharp
+    }
+    test "csharp2" {
+      assertCanSerializeAndDeserialize csharp2
+    }
+    test "enum" {
+      assertCanSerializeAndDeserialize enum
+    }
+    test "enum2" {
+      assertCanSerializeAndDeserialize enum2
+    }
+    test "enum3" {
+      assertCanSerializeAndDeserialize enum3
+    }
+    ptest "fsharp" {
+      assertCanSerializeAndDeserialize fsharp
+    }
+    ptest "fsharp2" {
+      assertCanSerializeAndDeserialize fsharp2
+    }
+    ptest "argu" {
+      assertCanSerializeAndDeserialize arguAssembly
+    }
+    ptest "chiron"{
+      assertCanSerializeAndDeserialize chironAssembly
+    }
+  ]
 

--- a/tests/SynVer.Tests/SurfaceAreaTests.fs
+++ b/tests/SynVer.Tests/SurfaceAreaTests.fs
@@ -1,57 +1,58 @@
 module SynVer.SurfaceAreaTests
 open SynVer
-open NUnit.Framework
+open Expecto
 open TestHelper.Types
 
-[<Test>]
-let ``Union surface area`` () =
-  let t = typeof<Union>
-  let area = SurfaceArea.ofType t
-  let typ= area.Type
-  let expected =[ UnionCase (typ,"FooBar", [])
-                  UnionCase (typ,"Foo",[])
-                  UnionCase (typ,"Bar",[])
-                ]
-  Assert.AreEqual(expected, area.UnionCases.Value.Cases)
-  Assert.IsTrue(area.Enum.IsNone)
+[<Tests>]
+let tests =
+  testList "Surface area" [
+    test "Union surface area" {
+      let t = typeof<Union>
+      let area = SurfaceArea.ofType t
+      let typ= area.Type
+      let expected =[ UnionCase (typ,"FooBar", [])
+                      UnionCase (typ,"Foo",[])
+                      UnionCase (typ,"Bar",[])
+                    ]
+      Expect.equal expected area.UnionCases.Value.Cases "union cases"
+      Expect.isTrue (area.Enum.IsNone) "is none"
+    }
+    test "Union with params surface area" {
+      let t = typeof<UnionWithParam>
+      let area = SurfaceArea.ofType t
+      let typ= area.Type
+      let expected = [
+                      UnionCase (typ, "Foo",
+                        [{Type= {FullName="System.Tuple<System.Int32,System.Double>"}; Name=null }])
+                      UnionCase (typ, "Bar",
+                        [{Type={FullName="System.Double"}; Name=null}])
+                      ]
 
-[<Test>]
-let ``Union with params surface area`` () =
-  let t = typeof<UnionWithParam>
-  let area = SurfaceArea.ofType t
-  let typ= area.Type
-  let expected = [
-                  UnionCase (typ, "Foo",
-                    [{Type= {FullName="System.Tuple<System.Int32,System.Double>"}; Name=null }])
-                  UnionCase (typ, "Bar",
-                    [{Type={FullName="System.Double"}; Name=null}])
-                  ]
+      Expect.equal expected area.UnionCases.Value.Cases "union cases"
+      Expect.isTrue (area.Enum.IsNone) "is none"
+    }
+    test "Union with names surface area" {
+      let t = typeof<UnionCaseWithName>
+      let area = SurfaceArea.ofType t
+      let typ= area.Type
+      let expected = [
+                      UnionCase (typ, "Foo",
+                          [{Type={FullName="System.Int32"}; Name="num"}
+                           {Type={FullName="System.Double"};Name="diff"}])
+                      UnionCase (typ, "Bar",
+                          [{Type={FullName="System.Double"};Name="diff"}])
+                      ]
+      //printf "%A" area.UnionCases.Value.Cases
+      Expect.equal expected area.UnionCases.Value.Cases "union cases"
+      Expect.isTrue (area.Enum.IsNone) "is none"
+    }
 
-  Assert.AreEqual(expected, area.UnionCases.Value.Cases)
-  Assert.IsTrue(area.Enum.IsNone)
+    test "Enum surface area" {
+      let t = typeof<EnumType>
+      let area = SurfaceArea.ofType t
+      let expected = [("FooBar","0"); ("Foo","1"); ("Bar","2")]
 
-[<Test>]
-let ``Union with names surface area`` () =
-  let t = typeof<UnionCaseWithName>
-  let area = SurfaceArea.ofType t
-  let typ= area.Type
-  let expected = [
-                  UnionCase (typ, "Foo",
-                      [{Type={FullName="System.Int32"}; Name="num"}
-                       {Type={FullName="System.Double"};Name="diff"}])
-                  UnionCase (typ, "Bar",
-                      [{Type={FullName="System.Double"};Name="diff"}])
-                  ]
-  //printf "%A" area.UnionCases.Value.Cases
-  Assert.AreEqual(expected, area.UnionCases.Value.Cases)
-  Assert.IsTrue(area.Enum.IsNone)
-
-
-[<Test>]
-let ``Enum surface area`` () =
-  let t = typeof<EnumType>
-  let area = SurfaceArea.ofType t
-  let expected = [("FooBar","0"); ("Foo","1"); ("Bar","2")]
-
-  Assert.AreEqual(expected, area.Enum.Value)
-  Assert.IsTrue(area.UnionCases.IsNone)
+      Expect.equal expected area.Enum.Value "enum value"
+      Expect.isTrue (area.UnionCases.IsNone) "is none"
+    }
+  ]

--- a/tests/SynVer.Tests/SynVer.Tests.fsproj
+++ b/tests/SynVer.Tests/SynVer.Tests.fsproj
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -5,7 +6,7 @@
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <SchemaVersion>2.0</SchemaVersion>
     <ProjectGuid>26d49ae5-f879-4321-a1aa-e7c35b60c874</ProjectGuid>
-    <OutputType>Library</OutputType>
+    <OutputType>Exe</OutputType>
     <RootNamespace>SyntacticVersioning.Tests</RootNamespace>
     <AssemblyName>SyntacticVersioning.Tests</AssemblyName>
     <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
@@ -68,6 +69,7 @@
     <None Include="paket.references" />
     <Content Include="App.config" />
     <Compile Include="SerializationTests.fs" />
+    <Compile Include="Program.fs" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="mscorlib" />
@@ -82,7 +84,7 @@
     </ProjectReference>
   </ItemGroup>
   <Choose>
-    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.5.1' Or $(TargetFrameworkVersion) == 'v4.5.2' Or $(TargetFrameworkVersion) == 'v4.5.3' Or $(TargetFrameworkVersion) == 'v4.6' Or $(TargetFrameworkVersion) == 'v4.6.1' Or $(TargetFrameworkVersion) == 'v4.6.2' Or $(TargetFrameworkVersion) == 'v4.6.3')">
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.5.1' Or $(TargetFrameworkVersion) == 'v4.5.2' Or $(TargetFrameworkVersion) == 'v4.5.3' Or $(TargetFrameworkVersion) == 'v4.6' Or $(TargetFrameworkVersion) == 'v4.6.1' Or $(TargetFrameworkVersion) == 'v4.6.2' Or $(TargetFrameworkVersion) == 'v4.6.3' Or $(TargetFrameworkVersion) == 'v4.7' Or $(TargetFrameworkVersion) == 'v4.7.1')">
       <ItemGroup>
         <Reference Include="Aether">
           <HintPath>..\..\packages\Aether\lib\net35\Aether.dll</HintPath>
@@ -93,7 +95,18 @@
     </When>
   </Choose>
   <Choose>
-    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.5.1' Or $(TargetFrameworkVersion) == 'v4.5.2' Or $(TargetFrameworkVersion) == 'v4.5.3' Or $(TargetFrameworkVersion) == 'v4.6' Or $(TargetFrameworkVersion) == 'v4.6.1' Or $(TargetFrameworkVersion) == 'v4.6.2' Or $(TargetFrameworkVersion) == 'v4.6.3')">
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.5.1' Or $(TargetFrameworkVersion) == 'v4.5.2' Or $(TargetFrameworkVersion) == 'v4.5.3' Or $(TargetFrameworkVersion) == 'v4.6' Or $(TargetFrameworkVersion) == 'v4.6.1' Or $(TargetFrameworkVersion) == 'v4.6.2' Or $(TargetFrameworkVersion) == 'v4.6.3' Or $(TargetFrameworkVersion) == 'v4.7' Or $(TargetFrameworkVersion) == 'v4.7.1')">
+      <ItemGroup>
+        <Reference Include="Argu">
+          <HintPath>..\..\packages\Argu\lib\net40\Argu.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Choose>
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.5.1' Or $(TargetFrameworkVersion) == 'v4.5.2' Or $(TargetFrameworkVersion) == 'v4.5.3' Or $(TargetFrameworkVersion) == 'v4.6' Or $(TargetFrameworkVersion) == 'v4.6.1' Or $(TargetFrameworkVersion) == 'v4.6.2' Or $(TargetFrameworkVersion) == 'v4.6.3' Or $(TargetFrameworkVersion) == 'v4.7' Or $(TargetFrameworkVersion) == 'v4.7.1')">
       <ItemGroup>
         <Reference Include="Chiron">
           <HintPath>..\..\packages\Chiron\lib\net40\Chiron.dll</HintPath>
@@ -104,7 +117,29 @@
     </When>
   </Choose>
   <Choose>
-    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.5.1' Or $(TargetFrameworkVersion) == 'v4.5.2' Or $(TargetFrameworkVersion) == 'v4.5.3' Or $(TargetFrameworkVersion) == 'v4.6' Or $(TargetFrameworkVersion) == 'v4.6.1' Or $(TargetFrameworkVersion) == 'v4.6.2' Or $(TargetFrameworkVersion) == 'v4.6.3')">
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.5.1' Or $(TargetFrameworkVersion) == 'v4.5.2' Or $(TargetFrameworkVersion) == 'v4.5.3' Or $(TargetFrameworkVersion) == 'v4.6' Or $(TargetFrameworkVersion) == 'v4.6.1' Or $(TargetFrameworkVersion) == 'v4.6.2' Or $(TargetFrameworkVersion) == 'v4.6.3' Or $(TargetFrameworkVersion) == 'v4.7' Or $(TargetFrameworkVersion) == 'v4.7.1')">
+      <ItemGroup>
+        <Reference Include="Expecto">
+          <HintPath>..\..\packages\Expecto\lib\net40\Expecto.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Choose>
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.5.1' Or $(TargetFrameworkVersion) == 'v4.5.2' Or $(TargetFrameworkVersion) == 'v4.5.3' Or $(TargetFrameworkVersion) == 'v4.6' Or $(TargetFrameworkVersion) == 'v4.6.1' Or $(TargetFrameworkVersion) == 'v4.6.2' Or $(TargetFrameworkVersion) == 'v4.6.3' Or $(TargetFrameworkVersion) == 'v4.7' Or $(TargetFrameworkVersion) == 'v4.7.1')">
+      <ItemGroup>
+        <Reference Include="Expecto.FsCheck">
+          <HintPath>..\..\packages\Expecto.FsCheck\lib\net40\Expecto.FsCheck.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Choose>
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.5.1' Or $(TargetFrameworkVersion) == 'v4.5.2' Or $(TargetFrameworkVersion) == 'v4.5.3' Or $(TargetFrameworkVersion) == 'v4.6' Or $(TargetFrameworkVersion) == 'v4.6.1' Or $(TargetFrameworkVersion) == 'v4.6.2' Or $(TargetFrameworkVersion) == 'v4.6.3' Or $(TargetFrameworkVersion) == 'v4.7' Or $(TargetFrameworkVersion) == 'v4.7.1')">
       <ItemGroup>
         <Reference Include="FParsec">
           <HintPath>..\..\packages\FParsec\lib\net40-client\FParsec.dll</HintPath>
@@ -120,7 +155,27 @@
     </When>
   </Choose>
   <Choose>
-    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.5.1' Or $(TargetFrameworkVersion) == 'v4.5.2' Or $(TargetFrameworkVersion) == 'v4.5.3' Or $(TargetFrameworkVersion) == 'v4.6' Or $(TargetFrameworkVersion) == 'v4.6.1' Or $(TargetFrameworkVersion) == 'v4.6.2' Or $(TargetFrameworkVersion) == 'v4.6.3')">
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.5.2' Or $(TargetFrameworkVersion) == 'v4.5.3' Or $(TargetFrameworkVersion) == 'v4.6' Or $(TargetFrameworkVersion) == 'v4.6.1' Or $(TargetFrameworkVersion) == 'v4.6.2' Or $(TargetFrameworkVersion) == 'v4.6.3' Or $(TargetFrameworkVersion) == 'v4.7' Or $(TargetFrameworkVersion) == 'v4.7.1')">
+      <ItemGroup>
+        <Reference Include="FsCheck">
+          <HintPath>..\..\packages\FsCheck\lib\net452\FsCheck.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And $(TargetFrameworkVersion) == 'v4.5.1'">
+      <ItemGroup>
+        <Reference Include="FsCheck">
+          <HintPath>..\..\packages\FsCheck\lib\portable-net45+netcore45\FsCheck.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Choose>
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.5.1' Or $(TargetFrameworkVersion) == 'v4.5.2' Or $(TargetFrameworkVersion) == 'v4.5.3' Or $(TargetFrameworkVersion) == 'v4.6' Or $(TargetFrameworkVersion) == 'v4.6.1' Or $(TargetFrameworkVersion) == 'v4.6.2' Or $(TargetFrameworkVersion) == 'v4.6.3' Or $(TargetFrameworkVersion) == 'v4.7' Or $(TargetFrameworkVersion) == 'v4.7.1')">
       <ItemGroup>
         <Reference Include="FSharp.Core">
           <HintPath>..\..\packages\FSharp.Core\lib\net45\FSharp.Core.dll</HintPath>
@@ -131,7 +186,377 @@
     </When>
   </Choose>
   <Choose>
-    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.5.1' Or $(TargetFrameworkVersion) == 'v4.5.2' Or $(TargetFrameworkVersion) == 'v4.5.3' Or $(TargetFrameworkVersion) == 'v4.6' Or $(TargetFrameworkVersion) == 'v4.6.1' Or $(TargetFrameworkVersion) == 'v4.6.2' Or $(TargetFrameworkVersion) == 'v4.6.3')">
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.6' Or $(TargetFrameworkVersion) == 'v4.6.1' Or $(TargetFrameworkVersion) == 'v4.6.2' Or $(TargetFrameworkVersion) == 'v4.6.3' Or $(TargetFrameworkVersion) == 'v4.7' Or $(TargetFrameworkVersion) == 'v4.7.1')">
+      <ItemGroup>
+        <Reference Include="Microsoft.Win32.Primitives">
+          <HintPath>..\..\packages\Microsoft.Win32.Primitives\lib\net46\Microsoft.Win32.Primitives.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Choose>
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.5.1' Or $(TargetFrameworkVersion) == 'v4.5.2' Or $(TargetFrameworkVersion) == 'v4.5.3' Or $(TargetFrameworkVersion) == 'v4.6' Or $(TargetFrameworkVersion) == 'v4.6.1' Or $(TargetFrameworkVersion) == 'v4.6.2' Or $(TargetFrameworkVersion) == 'v4.6.3' Or $(TargetFrameworkVersion) == 'v4.7' Or $(TargetFrameworkVersion) == 'v4.7.1')">
+      <ItemGroup>
+        <Reference Include="Mono.Cecil">
+          <HintPath>..\..\packages\Mono.Cecil\lib\net45\Mono.Cecil.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+        <Reference Include="Mono.Cecil.Mdb">
+          <HintPath>..\..\packages\Mono.Cecil\lib\net45\Mono.Cecil.Mdb.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+        <Reference Include="Mono.Cecil.Pdb">
+          <HintPath>..\..\packages\Mono.Cecil\lib\net45\Mono.Cecil.Pdb.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+        <Reference Include="Mono.Cecil.Rocks">
+          <HintPath>..\..\packages\Mono.Cecil\lib\net45\Mono.Cecil.Rocks.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Choose>
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.6' Or $(TargetFrameworkVersion) == 'v4.6.1' Or $(TargetFrameworkVersion) == 'v4.6.2')">
+      <ItemGroup>
+        <Reference Include="System.AppContext">
+          <HintPath>..\..\packages\System.AppContext\lib\net46\System.AppContext.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.6.3' Or $(TargetFrameworkVersion) == 'v4.7' Or $(TargetFrameworkVersion) == 'v4.7.1')">
+      <ItemGroup>
+        <Reference Include="System.AppContext">
+          <HintPath>..\..\packages\System.AppContext\lib\net463\System.AppContext.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Choose>
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.6' Or $(TargetFrameworkVersion) == 'v4.6.1' Or $(TargetFrameworkVersion) == 'v4.6.2' Or $(TargetFrameworkVersion) == 'v4.6.3' Or $(TargetFrameworkVersion) == 'v4.7' Or $(TargetFrameworkVersion) == 'v4.7.1')">
+      <ItemGroup>
+        <Reference Include="System.Console">
+          <HintPath>..\..\packages\System.Console\lib\net46\System.Console.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Choose>
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.6.2' Or $(TargetFrameworkVersion) == 'v4.6.3' Or $(TargetFrameworkVersion) == 'v4.7' Or $(TargetFrameworkVersion) == 'v4.7.1')">
+      <ItemGroup>
+        <Reference Include="System.Diagnostics.Tracing">
+          <HintPath>..\..\packages\System.Diagnostics.Tracing\lib\net462\System.Diagnostics.Tracing.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Choose>
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.6' Or $(TargetFrameworkVersion) == 'v4.6.1' Or $(TargetFrameworkVersion) == 'v4.6.2' Or $(TargetFrameworkVersion) == 'v4.6.3' Or $(TargetFrameworkVersion) == 'v4.7' Or $(TargetFrameworkVersion) == 'v4.7.1')">
+      <ItemGroup>
+        <Reference Include="System.Globalization.Calendars">
+          <HintPath>..\..\packages\System.Globalization.Calendars\lib\net46\System.Globalization.Calendars.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Choose>
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.6.2' Or $(TargetFrameworkVersion) == 'v4.6.3' Or $(TargetFrameworkVersion) == 'v4.7' Or $(TargetFrameworkVersion) == 'v4.7.1')">
+      <ItemGroup>
+        <Reference Include="System.IO">
+          <HintPath>..\..\packages\System.IO\lib\net462\System.IO.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Choose>
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.6' Or $(TargetFrameworkVersion) == 'v4.6.1' Or $(TargetFrameworkVersion) == 'v4.6.2' Or $(TargetFrameworkVersion) == 'v4.6.3' Or $(TargetFrameworkVersion) == 'v4.7' Or $(TargetFrameworkVersion) == 'v4.7.1')">
+      <ItemGroup>
+        <Reference Include="System.IO.Compression">
+          <HintPath>..\..\packages\System.IO.Compression\lib\net46\System.IO.Compression.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Choose>
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.6' Or $(TargetFrameworkVersion) == 'v4.6.1' Or $(TargetFrameworkVersion) == 'v4.6.2' Or $(TargetFrameworkVersion) == 'v4.6.3' Or $(TargetFrameworkVersion) == 'v4.7' Or $(TargetFrameworkVersion) == 'v4.7.1')">
+      <ItemGroup>
+        <Reference Include="System.IO.Compression.FileSystem">
+          <Paket>True</Paket>
+        </Reference>
+        <Reference Include="System.IO.Compression.ZipFile">
+          <HintPath>..\..\packages\System.IO.Compression.ZipFile\lib\net46\System.IO.Compression.ZipFile.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Choose>
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.6' Or $(TargetFrameworkVersion) == 'v4.6.1' Or $(TargetFrameworkVersion) == 'v4.6.2' Or $(TargetFrameworkVersion) == 'v4.6.3' Or $(TargetFrameworkVersion) == 'v4.7' Or $(TargetFrameworkVersion) == 'v4.7.1')">
+      <ItemGroup>
+        <Reference Include="System.IO.FileSystem">
+          <HintPath>..\..\packages\System.IO.FileSystem\lib\net46\System.IO.FileSystem.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Choose>
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.6' Or $(TargetFrameworkVersion) == 'v4.6.1' Or $(TargetFrameworkVersion) == 'v4.6.2' Or $(TargetFrameworkVersion) == 'v4.6.3' Or $(TargetFrameworkVersion) == 'v4.7' Or $(TargetFrameworkVersion) == 'v4.7.1')">
+      <ItemGroup>
+        <Reference Include="System.IO.FileSystem.Primitives">
+          <HintPath>..\..\packages\System.IO.FileSystem.Primitives\lib\net46\System.IO.FileSystem.Primitives.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Choose>
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.6.3' Or $(TargetFrameworkVersion) == 'v4.7' Or $(TargetFrameworkVersion) == 'v4.7.1')">
+      <ItemGroup>
+        <Reference Include="System.Linq">
+          <HintPath>..\..\packages\System.Linq\lib\net463\System.Linq.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Choose>
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.6.3' Or $(TargetFrameworkVersion) == 'v4.7' Or $(TargetFrameworkVersion) == 'v4.7.1')">
+      <ItemGroup>
+        <Reference Include="System.Linq.Expressions">
+          <HintPath>..\..\packages\System.Linq.Expressions\lib\net463\System.Linq.Expressions.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Choose>
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.6' Or $(TargetFrameworkVersion) == 'v4.6.1' Or $(TargetFrameworkVersion) == 'v4.6.2' Or $(TargetFrameworkVersion) == 'v4.6.3' Or $(TargetFrameworkVersion) == 'v4.7' Or $(TargetFrameworkVersion) == 'v4.7.1')">
+      <ItemGroup>
+        <Reference Include="System.Net.Http">
+          <HintPath>..\..\packages\System.Net.Http\lib\net46\System.Net.Http.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Choose>
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.6' Or $(TargetFrameworkVersion) == 'v4.6.1' Or $(TargetFrameworkVersion) == 'v4.6.2' Or $(TargetFrameworkVersion) == 'v4.6.3' Or $(TargetFrameworkVersion) == 'v4.7' Or $(TargetFrameworkVersion) == 'v4.7.1')">
+      <ItemGroup>
+        <Reference Include="System.Net.Sockets">
+          <HintPath>..\..\packages\System.Net.Sockets\lib\net46\System.Net.Sockets.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Choose>
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.6.2' Or $(TargetFrameworkVersion) == 'v4.6.3' Or $(TargetFrameworkVersion) == 'v4.7' Or $(TargetFrameworkVersion) == 'v4.7.1')">
+      <ItemGroup>
+        <Reference Include="System.Reflection">
+          <HintPath>..\..\packages\System.Reflection\lib\net462\System.Reflection.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Choose>
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.6' Or $(TargetFrameworkVersion) == 'v4.6.1')">
+      <ItemGroup>
+        <Reference Include="System.ComponentModel.Composition">
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.6.2' Or $(TargetFrameworkVersion) == 'v4.6.3' Or $(TargetFrameworkVersion) == 'v4.7' Or $(TargetFrameworkVersion) == 'v4.7.1')">
+      <ItemGroup>
+        <Reference Include="System.ComponentModel.Composition">
+          <Paket>True</Paket>
+        </Reference>
+        <Reference Include="System.Runtime">
+          <HintPath>..\..\packages\System.Runtime\lib\net462\System.Runtime.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Choose>
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.6.2' Or $(TargetFrameworkVersion) == 'v4.6.3' Or $(TargetFrameworkVersion) == 'v4.7' Or $(TargetFrameworkVersion) == 'v4.7.1')">
+      <ItemGroup>
+        <Reference Include="System.Runtime.Extensions">
+          <HintPath>..\..\packages\System.Runtime.Extensions\lib\net462\System.Runtime.Extensions.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Choose>
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And $(TargetFrameworkVersion) == 'v4.6.2'">
+      <ItemGroup>
+        <Reference Include="System.Runtime.InteropServices">
+          <HintPath>..\..\packages\System.Runtime.InteropServices\lib\net462\System.Runtime.InteropServices.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.6.3' Or $(TargetFrameworkVersion) == 'v4.7' Or $(TargetFrameworkVersion) == 'v4.7.1')">
+      <ItemGroup>
+        <Reference Include="System.Runtime.InteropServices">
+          <HintPath>..\..\packages\System.Runtime.InteropServices\lib\net463\System.Runtime.InteropServices.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Choose>
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.6' Or $(TargetFrameworkVersion) == 'v4.6.1' Or $(TargetFrameworkVersion) == 'v4.6.2' Or $(TargetFrameworkVersion) == 'v4.6.3' Or $(TargetFrameworkVersion) == 'v4.7' Or $(TargetFrameworkVersion) == 'v4.7.1')">
+      <ItemGroup>
+        <Reference Include="System.Runtime.InteropServices.RuntimeInformation">
+          <HintPath>..\..\packages\System.Runtime.InteropServices.RuntimeInformation\lib\net45\System.Runtime.InteropServices.RuntimeInformation.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Choose>
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And $(TargetFrameworkVersion) == 'v4.6'">
+      <ItemGroup>
+        <Reference Include="System.Security.Cryptography.Algorithms">
+          <HintPath>..\..\packages\System.Security.Cryptography.Algorithms\lib\net46\System.Security.Cryptography.Algorithms.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.6.1' Or $(TargetFrameworkVersion) == 'v4.6.2')">
+      <ItemGroup>
+        <Reference Include="System.Security.Cryptography.Algorithms">
+          <HintPath>..\..\packages\System.Security.Cryptography.Algorithms\lib\net461\System.Security.Cryptography.Algorithms.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.6.3' Or $(TargetFrameworkVersion) == 'v4.7' Or $(TargetFrameworkVersion) == 'v4.7.1')">
+      <ItemGroup>
+        <Reference Include="System.Security.Cryptography.Algorithms">
+          <HintPath>..\..\packages\System.Security.Cryptography.Algorithms\lib\net463\System.Security.Cryptography.Algorithms.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Choose>
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.6' Or $(TargetFrameworkVersion) == 'v4.6.1' Or $(TargetFrameworkVersion) == 'v4.6.2' Or $(TargetFrameworkVersion) == 'v4.6.3' Or $(TargetFrameworkVersion) == 'v4.7' Or $(TargetFrameworkVersion) == 'v4.7.1')">
+      <ItemGroup>
+        <Reference Include="System.Security.Cryptography.Encoding">
+          <HintPath>..\..\packages\System.Security.Cryptography.Encoding\lib\net46\System.Security.Cryptography.Encoding.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Choose>
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.6' Or $(TargetFrameworkVersion) == 'v4.6.1' Or $(TargetFrameworkVersion) == 'v4.6.2' Or $(TargetFrameworkVersion) == 'v4.6.3' Or $(TargetFrameworkVersion) == 'v4.7' Or $(TargetFrameworkVersion) == 'v4.7.1')">
+      <ItemGroup>
+        <Reference Include="System.Security.Cryptography.Primitives">
+          <HintPath>..\..\packages\System.Security.Cryptography.Primitives\lib\net46\System.Security.Cryptography.Primitives.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Choose>
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And $(TargetFrameworkVersion) == 'v4.6'">
+      <ItemGroup>
+        <Reference Include="System.Security.Cryptography.X509Certificates">
+          <HintPath>..\..\packages\System.Security.Cryptography.X509Certificates\lib\net46\System.Security.Cryptography.X509Certificates.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.6.1' Or $(TargetFrameworkVersion) == 'v4.6.2' Or $(TargetFrameworkVersion) == 'v4.6.3' Or $(TargetFrameworkVersion) == 'v4.7' Or $(TargetFrameworkVersion) == 'v4.7.1')">
+      <ItemGroup>
+        <Reference Include="System.Security.Cryptography.X509Certificates">
+          <HintPath>..\..\packages\System.Security.Cryptography.X509Certificates\lib\net461\System.Security.Cryptography.X509Certificates.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Choose>
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.6.3' Or $(TargetFrameworkVersion) == 'v4.7' Or $(TargetFrameworkVersion) == 'v4.7.1')">
+      <ItemGroup>
+        <Reference Include="System.Text.RegularExpressions">
+          <HintPath>..\..\packages\System.Text.RegularExpressions\lib\net463\System.Text.RegularExpressions.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Choose>
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.6' Or $(TargetFrameworkVersion) == 'v4.6.1' Or $(TargetFrameworkVersion) == 'v4.6.2' Or $(TargetFrameworkVersion) == 'v4.6.3' Or $(TargetFrameworkVersion) == 'v4.7' Or $(TargetFrameworkVersion) == 'v4.7.1')">
+      <ItemGroup>
+        <Reference Include="System.Threading.Thread">
+          <HintPath>..\..\packages\System.Threading.Thread\lib\net46\System.Threading.Thread.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Choose>
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And $(TargetFrameworkVersion) == 'v4.7.1'">
+      <ItemGroup>
+        <Reference Include="System.Threading.ThreadPool">
+          <HintPath>..\..\packages\System.Threading.ThreadPool\lib\net46\System.Threading.ThreadPool.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Choose>
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.5.1' Or $(TargetFrameworkVersion) == 'v4.5.2' Or $(TargetFrameworkVersion) == 'v4.5.3' Or $(TargetFrameworkVersion) == 'v4.6' Or $(TargetFrameworkVersion) == 'v4.6.1' Or $(TargetFrameworkVersion) == 'v4.6.2' Or $(TargetFrameworkVersion) == 'v4.6.3' Or $(TargetFrameworkVersion) == 'v4.7' Or $(TargetFrameworkVersion) == 'v4.7.1')">
       <ItemGroup>
         <Reference Include="System.ValueTuple">
           <HintPath>..\..\packages\System.ValueTuple\lib\netstandard1.0\System.ValueTuple.dll</HintPath>
@@ -141,11 +566,27 @@
       </ItemGroup>
     </When>
   </Choose>
-  <ItemGroup>
-    <Reference Include="nunit.framework">
-      <HintPath>..\..\packages\test\NUnit\lib\nunit.framework.dll</HintPath>
-      <Private>True</Private>
-      <Paket>True</Paket>
-    </Reference>
-  </ItemGroup>
+  <Choose>
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.6' Or $(TargetFrameworkVersion) == 'v4.6.1' Or $(TargetFrameworkVersion) == 'v4.6.2' Or $(TargetFrameworkVersion) == 'v4.6.3' Or $(TargetFrameworkVersion) == 'v4.7' Or $(TargetFrameworkVersion) == 'v4.7.1')">
+      <ItemGroup>
+        <Reference Include="System.Xml">
+          <Paket>True</Paket>
+        </Reference>
+        <Reference Include="System.Xml.ReaderWriter">
+          <HintPath>..\..\packages\System.Xml.ReaderWriter\lib\net46\System.Xml.ReaderWriter.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Choose>
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.6' Or $(TargetFrameworkVersion) == 'v4.6.1' Or $(TargetFrameworkVersion) == 'v4.6.2' Or $(TargetFrameworkVersion) == 'v4.6.3' Or $(TargetFrameworkVersion) == 'v4.7' Or $(TargetFrameworkVersion) == 'v4.7.1')">
+      <ItemGroup>
+        <Reference Include="System.Xml.Linq">
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
 </Project>

--- a/tests/SynVer.Tests/TestHelper.fs
+++ b/tests/SynVer.Tests/TestHelper.fs
@@ -9,8 +9,8 @@ let nlJoin (lines:string seq)=System.String.Join("\n",lines)
 let wTrim (str:string) = str.Trim([| '\n';'\t';' ';'\r' |])
 let asm = Assembly.GetExecutingAssembly()
 let testPath= Path.GetDirectoryName asm.Location
-let exampleProjectsPath = Path.GetFullPath( testPath </> ".."</>".."</>".."</>"ExampleProjects" )
-let packagesPath = Path.GetFullPath( testPath </> ".."</>".."</>".."</>".."</> "packages")
+let exampleProjectsPath = Path.GetFullPath( testPath </> ".."</>".."</>".."</> ".."</> "ExampleProjects" )
+let packagesPath = Path.GetFullPath( testPath </> ".."</>".."</>".."</>".."</> ".."</> "packages")
 let exampleProjectsLibPath = exampleProjectsPath </> "lib"
 // since all the dll-s have unique names, they can be loaded at the same time
 let csharp = exampleProjectsLibPath </> "Csharp.dll" |> Assembly.LoadFile

--- a/tests/SynVer.Tests/TestHelper.fs
+++ b/tests/SynVer.Tests/TestHelper.fs
@@ -9,8 +9,8 @@ let nlJoin (lines:string seq)=System.String.Join("\n",lines)
 let wTrim (str:string) = str.Trim([| '\n';'\t';' ';'\r' |])
 let asm = Assembly.GetExecutingAssembly()
 let testPath= Path.GetDirectoryName asm.Location
-let exampleProjectsPath = Path.GetFullPath( testPath </> ".."</>".."</>".."</> ".."</> "ExampleProjects" )
-let packagesPath = Path.GetFullPath( testPath </> ".."</>".."</>".."</>".."</> ".."</> "packages")
+let exampleProjectsPath = Path.GetFullPath( testPath </> ".."</>".."</>".."</> "ExampleProjects" )
+let packagesPath = Path.GetFullPath( testPath </> ".."</>".."</>".."</>".."</> "packages")
 let exampleProjectsLibPath = exampleProjectsPath </> "lib"
 // since all the dll-s have unique names, they can be loaded at the same time
 let csharp = exampleProjectsLibPath </> "Csharp.dll" |> Assembly.LoadFile

--- a/tests/SynVer.Tests/Tests.fs
+++ b/tests/SynVer.Tests/Tests.fs
@@ -1,39 +1,40 @@
 module SynVer.Tests
 open SynVer
-open NUnit.Framework
+open Expecto
 
 open TestHelper
-[<Test>]
-let ``csharp vs csharp2`` () =
-  let diff = Assemblies.diff csharp csharp2
-            |> nlJoin
-            |> wTrim
-  Assert.AreEqual ("", diff)
-  let bump = Assemblies.bump "1.0.0" csharp csharp2
-  Assert.AreEqual ( ("1.0.1", Patch), bump)
+[<Tests>]
+let tests =
+  testList "assembly diff" [
+    test "csharp vs csharp2" {
+      let diff = Assemblies.diff csharp csharp2
+                |> nlJoin
+                |> wTrim
+      Expect.equal "" diff "Empty diff"
+      let bump = Assemblies.bump "1.0.0" csharp csharp2
+      Expect.equal  ("1.0.1", Patch) bump "Patch change"
+    }
+    test "enum vs enum2" {
+      let diff = Assemblies.diff enum enum2
+                |> nlJoin
+                |> wTrim
+      Expect.equal enum2txt diff "enum 2 diff"
+      let bump = Assemblies.bump "1.0.0" enum enum2
+      Expect.equal  ("2.0.0", Major) bump "Major change"
+    }
 
-[<Test>]
-let ``enum vs enum2`` () =
-  let diff = Assemblies.diff enum enum2
-            |> nlJoin
-            |> wTrim
-  Assert.AreEqual (enum2txt, diff)
-  let bump = Assemblies.bump "1.0.0" enum enum2
-  Assert.AreEqual ( ("2.0.0", Major), bump)
-
-[<Test>]
-let ``enum vs enum3`` () =
-  let diff = Assemblies.diff enum enum3
-            |> nlJoin
-            |> wTrim
-  Assert.AreEqual (enum3txt, diff)
-  let bump = Assemblies.bump "1.0.0" enum enum3
-  Assert.AreEqual ( ("1.1.0", Minor), bump)
-
-[<Test>]
-let ``fsharp vs fsharp2`` () =
-  let diff = Assemblies.diff fsharp fsharp2
-            |> nlJoin
-            |> wTrim
-  Assert.AreEqual (fsharp2txt, diff)
-
+    test "enum vs enum3" {
+      let diff = Assemblies.diff enum enum3
+                |> nlJoin
+                |> wTrim
+      Expect.equal enum3txt diff "enum 3 diff"
+      let bump = Assemblies.bump "1.0.0" enum enum3
+      Expect.equal ("1.1.0", Minor) bump "Minor change"
+    }
+    test "fsharp vs fsharp2" {
+      let diff = Assemblies.diff fsharp fsharp2
+                |> nlJoin
+                |> wTrim
+      Expect.equal fsharp2txt diff "fsharp 2 diff"
+    }
+  ]

--- a/tests/SynVer.Tests/paket.references
+++ b/tests/SynVer.Tests/paket.references
@@ -1,5 +1,4 @@
 FSharp.Core
 Chiron
-group Test
-NUnit
-NUnit.Runners
+Expecto
+Expecto.FsCheck


### PR DESCRIPTION
- Using expecto to run tests (it's conceptually simpler than xunit/nunit)
- Using lisp style format to serialize and deserialize metadata, since there are super simple lisp style parsers for f# (so no need to pull in complicated libraries)
- Do not generate docs on travis (we can fix that later on)