### PR TITLE
Decompile instead of using reflection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -190,3 +190,4 @@ docs/content/license.md
 docs/content/release-notes.md
 .fake
 docs/tools/FSharp.Formatting.svclog
+.idea/

--- a/.paket/Paket.Restore.targets
+++ b/.paket/Paket.Restore.targets
@@ -43,22 +43,25 @@
     <!-- Step 1 Check if lockfile is properly restored -->
     <PropertyGroup>
       <PaketRestoreRequired>true</PaketRestoreRequired>
-      <NoWarn>$(NoWarn);NU1603</NoWarn>
+      <NoWarn>$(NoWarn);NU1603;NU1604;NU1605;NU1608</NoWarn>
     </PropertyGroup>
 
     <!-- Because ReadAllText is slow on osx/linux, try to find shasum and awk -->
     <PropertyGroup>
-        <PaketRestoreCachedHasher Condition="'$(OS)' != 'Windows_NT' And '$(PaketRestoreCachedHasher)' == '' And Exists('/usr/bin/shasum') And Exists('/usr/bin/awk')">/usr/bin/shasum $(PaketRestoreCacheFile) | /usr/bin/awk '{ print $1 }'</PaketRestoreCachedHasher>
-        <PaketRestoreLockFileHasher Condition="'$(OS)' != 'Windows_NT' And '$(PaketRestoreLockFileHash)' == '' And Exists('/usr/bin/shasum') And Exists('/usr/bin/awk')">/usr/bin/shasum $(PaketLockFilePath) | /usr/bin/awk '{ print $1 }'</PaketRestoreLockFileHasher>
+      <PaketRestoreCachedHasher Condition="'$(OS)' != 'Windows_NT' And '$(PaketRestoreCachedHasher)' == '' And Exists('/usr/bin/shasum') And Exists('/usr/bin/awk')">/usr/bin/shasum "$(PaketRestoreCacheFile)" | /usr/bin/awk '{ print $1 }'</PaketRestoreCachedHasher>
+      <PaketRestoreLockFileHasher Condition="'$(OS)' != 'Windows_NT' And '$(PaketRestoreLockFileHash)' == '' And Exists('/usr/bin/shasum') And Exists('/usr/bin/awk')">/usr/bin/shasum "$(PaketLockFilePath)" | /usr/bin/awk '{ print $1 }'</PaketRestoreLockFileHasher>
     </PropertyGroup>
 
     <!-- If shasum and awk exist get the hashes -->
     <Exec StandardOutputImportance="Low" Condition=" '$(PaketRestoreCachedHasher)' != '' " Command="$(PaketRestoreCachedHasher)" ConsoleToMSBuild='true'>
-        <Output TaskParameter="ConsoleOutput" PropertyName="PaketRestoreCachedHash" />
+      <Output TaskParameter="ConsoleOutput" PropertyName="PaketRestoreCachedHash" />
     </Exec>
     <Exec StandardOutputImportance="Low" Condition=" '$(PaketRestoreLockFileHasher)' != '' " Command="$(PaketRestoreLockFileHasher)" ConsoleToMSBuild='true'>
-        <Output TaskParameter="ConsoleOutput" PropertyName="PaketRestoreLockFileHash" />
+      <Output TaskParameter="ConsoleOutput" PropertyName="PaketRestoreLockFileHash" />
     </Exec>
+
+    <!-- Debug whats going on -->
+    <Message Importance="low" Text="calling paket restore with targetframework=$(TargetFramework) targetframeworks=$(TargetFrameworks)" />
 
     <PropertyGroup Condition="Exists('$(PaketRestoreCacheFile)') ">
       <!-- if no hash has been done yet fall back to just reading in the files and comparing them -->
@@ -69,11 +72,22 @@
       <PaketRestoreRequired Condition=" '$(PaketRestoreLockFileHash)' == '' ">true</PaketRestoreRequired>
     </PropertyGroup>
 
+    <PropertyGroup Condition="'$(PaketPropsVersion)' != '5.174.2' ">
+      <PaketRestoreRequired>true</PaketRestoreRequired>
+    </PropertyGroup>
+
     <!-- Do a global restore if required -->
     <Exec Command='$(PaketBootStrapperCommand)' Condition="Exists('$(PaketBootStrapperExePath)') AND !(Exists('$(PaketExePath)'))" ContinueOnError="false" />
     <Exec Command='$(PaketCommand) restore' Condition=" '$(PaketRestoreRequired)' == 'true' " ContinueOnError="false" />
 
     <!-- Step 2 Detect project specific changes -->
+    <ItemGroup>
+      <MyTargetFrameworks Condition="'$(TargetFramework)' != '' " Include="$(TargetFramework)"></MyTargetFrameworks>
+      <!-- Don't include all frameworks when msbuild explicitly asks for a single one -->
+      <MyTargetFrameworks Condition="'$(TargetFrameworks)' != '' AND '$(TargetFramework)' == '' " Include="$(TargetFrameworks)"></MyTargetFrameworks>
+      <PaketResolvedFilePaths Include="@(MyTargetFrameworks -> '$(MSBuildProjectDirectory)\obj\$(MSBuildProjectFile).%(Identity).paket.resolved')"></PaketResolvedFilePaths>
+    </ItemGroup>
+    <Message Importance="low" Text="MyTargetFrameworks=@(MyTargetFrameworks) PaketResolvedFilePaths=@(PaketResolvedFilePaths)" />
     <PropertyGroup>
       <PaketReferencesCachedFilePath>$(MSBuildProjectDirectory)\obj\$(MSBuildProjectFile).paket.references.cached</PaketReferencesCachedFilePath>
       <!-- MyProject.fsproj.paket.references has the highest precedence -->
@@ -82,7 +96,9 @@
       <PaketOriginalReferencesFilePath Condition=" !Exists('$(PaketOriginalReferencesFilePath)')">$(MSBuildProjectDirectory)\$(MSBuildProjectName).paket.references</PaketOriginalReferencesFilePath>
       <!-- paket.references -->
       <PaketOriginalReferencesFilePath Condition=" !Exists('$(PaketOriginalReferencesFilePath)')">$(MSBuildProjectDirectory)\paket.references</PaketOriginalReferencesFilePath>
-      <PaketResolvedFilePath>$(MSBuildProjectDirectory)\obj\$(MSBuildProjectFile).$(TargetFramework).paket.resolved</PaketResolvedFilePath>
+
+      <DoAllResolvedFilesExist>false</DoAllResolvedFilesExist>
+      <DoAllResolvedFilesExist Condition="Exists(%(PaketResolvedFilePaths.Identity))">true</DoAllResolvedFilesExist>
       <PaketRestoreRequired>true</PaketRestoreRequired>
       <PaketRestoreRequiredReason>references-file-or-cache-not-found</PaketRestoreRequiredReason>
     </PropertyGroup>
@@ -101,32 +117,40 @@
     </PropertyGroup>
 
     <!-- Step 2 b detect relevant changes in project file (new targetframework) -->
-    <PropertyGroup Condition=" !Exists('$(PaketResolvedFilePath)') AND '$(TargetFramework)' != '' ">
+    <PropertyGroup Condition=" '$(DoAllResolvedFilesExist)' != 'true' ">
       <PaketRestoreRequired>true</PaketRestoreRequired>
-      <PaketRestoreRequiredReason>target-framework '$(TargetFramework)'</PaketRestoreRequiredReason>
+      <PaketRestoreRequiredReason>target-framework '$(TargetFramework)' or '$(TargetFrameworks)' files @(PaketResolvedFilePaths)</PaketRestoreRequiredReason>
     </PropertyGroup>
 
     <!-- Step 3 Restore project specific stuff if required -->
     <Message Condition=" '$(PaketRestoreRequired)' == 'true' " Importance="low" Text="Detected a change ('$(PaketRestoreRequiredReason)') in the project file '$(MSBuildProjectFullPath)', calling paket restore" />
-    <Exec Command='$(PaketCommand) restore --project "$(MSBuildProjectFullPath)"' Condition=" '$(PaketRestoreRequired)' == 'true' " ContinueOnError="false" />
+    <Exec Command='$(PaketCommand) restore --project "$(MSBuildProjectFullPath)" --target-framework "$(TargetFrameworks)"' Condition=" '$(PaketRestoreRequired)' == 'true' AND '$(TargetFramework)' == '' " ContinueOnError="false" />
+    <Exec Command='$(PaketCommand) restore --project "$(MSBuildProjectFullPath)" --target-framework "$(TargetFramework)"' Condition=" '$(PaketRestoreRequired)' == 'true' AND '$(TargetFramework)' != '' " ContinueOnError="false" />
 
     <!-- This shouldn't actually happen, but just to be sure. -->
-    <Error Condition=" !Exists('$(PaketResolvedFilePath)') AND '$(TargetFramework)' != '' AND '$(ResolveNuGetPackages)' != 'False' " Text="Paket file '$(PaketResolvedFilePath)' is missing while restoring $(MSBuildProjectFile). Please delete 'paket-files/paket.restore.cached' and call 'paket restore'." />
+    <PropertyGroup>
+      <DoAllResolvedFilesExist>false</DoAllResolvedFilesExist>
+      <DoAllResolvedFilesExist Condition="Exists(%(PaketResolvedFilePaths.Identity))">true</DoAllResolvedFilesExist>
+    </PropertyGroup>
+    <Error Condition=" '$(DoAllResolvedFilesExist)' != 'true' AND '$(ResolveNuGetPackages)' != 'False' " Text="One Paket file '@(PaketResolvedFilePaths)' is missing while restoring $(MSBuildProjectFile). Please delete 'paket-files/paket.restore.cached' and call 'paket restore'." />
 
     <!-- Step 4 forward all msbuild properties (PackageReference, DotNetCliToolReference) to msbuild -->
-    <ReadLinesFromFile Condition="Exists('$(PaketResolvedFilePath)')" File="$(PaketResolvedFilePath)" >
+    <ReadLinesFromFile Condition="($(DesignTimeBuild) != true OR '$(PaketPropsLoaded)' != 'true') AND '@(PaketResolvedFilePaths)' != ''" File="%(PaketResolvedFilePaths.Identity)" >
       <Output TaskParameter="Lines" ItemName="PaketReferencesFileLines"/>
     </ReadLinesFromFile>
 
-    <ItemGroup Condition=" Exists('$(PaketResolvedFilePath)') AND '@(PaketReferencesFileLines)' != '' " >
+    <ItemGroup Condition="($(DesignTimeBuild) != true OR '$(PaketPropsLoaded)' != 'true') AND '@(PaketReferencesFileLines)' != '' " >
       <PaketReferencesFileLinesInfo Include="@(PaketReferencesFileLines)" >
         <PackageName>$([System.String]::Copy('%(PaketReferencesFileLines.Identity)').Split(',')[0])</PackageName>
         <PackageVersion>$([System.String]::Copy('%(PaketReferencesFileLines.Identity)').Split(',')[1])</PackageVersion>
         <AllPrivateAssets>$([System.String]::Copy('%(PaketReferencesFileLines.Identity)').Split(',')[4])</AllPrivateAssets>
+        <CopyLocal>$([System.String]::Copy('%(PaketReferencesFileLines.Identity)').Split(',')[5])</CopyLocal>
       </PaketReferencesFileLinesInfo>
       <PackageReference Include="%(PaketReferencesFileLinesInfo.PackageName)">
         <Version>%(PaketReferencesFileLinesInfo.PackageVersion)</Version>
-        <PrivateAssets Condition="%(PaketReferencesFileLinesInfo.AllPrivateAssets) == 'true'">All</PrivateAssets>
+        <PrivateAssets Condition=" ('%(PaketReferencesFileLinesInfo.AllPrivateAssets)' == 'true') Or ('$(PackAsTool)' == 'true') ">All</PrivateAssets>
+        <ExcludeAssets Condition="%(PaketReferencesFileLinesInfo.CopyLocal) == 'false'">runtime</ExcludeAssets>
+        <Publish Condition=" '$(PackAsTool)' == 'true' ">true</Publish>
       </PackageReference>
     </ItemGroup>
 
@@ -183,8 +207,8 @@
 
     <ConvertToAbsolutePath Condition="@(_NuspecFiles) != ''" Paths="@(_NuspecFiles)">
       <Output TaskParameter="AbsolutePaths" PropertyName="NuspecFileAbsolutePath" />
-    </ConvertToAbsolutePath>      
-        
+    </ConvertToAbsolutePath>
+
 
     <!-- Call Pack -->
     <PackTask Condition="$(UseNewPack)"

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -12,3 +12,8 @@
 * Upgrade to FSharp.Core 4.1
 #### 0.0.6 - March 18 2017
 * Null reference bug, Version was missing ToString
+#### 0.0.7 - September 30 2018
+* Possibility to load assembly using Mono.Cecil
+* Filtering of compiler generated methods and inherited methods
+* Bugfix: Event rendered with wrong type
+* "Instance/Inheritance" -> "Instance"

--- a/src/SynVer.FAKE/AssemblyInfo.fs
+++ b/src/SynVer.FAKE/AssemblyInfo.fs
@@ -5,8 +5,8 @@ open System.Reflection
 [<assembly: AssemblyTitleAttribute("SynVer.FAKE")>]
 [<assembly: AssemblyProductAttribute("SynVer")>]
 [<assembly: AssemblyDescriptionAttribute("Syntactic (Semantic) Versioning for .NET libraries heavily inspired in elm-package (bump and diff)")>]
-[<assembly: AssemblyVersionAttribute("0.0.6")>]
-[<assembly: AssemblyFileVersionAttribute("0.0.6")>]
+[<assembly: AssemblyVersionAttribute("0.0.7")>]
+[<assembly: AssemblyFileVersionAttribute("0.0.7")>]
 [<assembly: AssemblyConfigurationAttribute("Release")>]
 do ()
 
@@ -14,6 +14,6 @@ module internal AssemblyVersionInformation =
     let [<Literal>] AssemblyTitle = "SynVer.FAKE"
     let [<Literal>] AssemblyProduct = "SynVer"
     let [<Literal>] AssemblyDescription = "Syntactic (Semantic) Versioning for .NET libraries heavily inspired in elm-package (bump and diff)"
-    let [<Literal>] AssemblyVersion = "0.0.6"
-    let [<Literal>] AssemblyFileVersion = "0.0.6"
+    let [<Literal>] AssemblyVersion = "0.0.7"
+    let [<Literal>] AssemblyFileVersion = "0.0.7"
     let [<Literal>] AssemblyConfiguration = "Release"

--- a/src/SynVer.Lib/AssemblyInfo.fs
+++ b/src/SynVer.Lib/AssemblyInfo.fs
@@ -5,8 +5,8 @@ open System.Reflection
 [<assembly: AssemblyTitleAttribute("SynVer.Lib")>]
 [<assembly: AssemblyProductAttribute("SynVer")>]
 [<assembly: AssemblyDescriptionAttribute("Syntactic (Semantic) Versioning for .NET libraries heavily inspired in elm-package (bump and diff)")>]
-[<assembly: AssemblyVersionAttribute("0.0.6")>]
-[<assembly: AssemblyFileVersionAttribute("0.0.6")>]
+[<assembly: AssemblyVersionAttribute("0.0.7")>]
+[<assembly: AssemblyFileVersionAttribute("0.0.7")>]
 [<assembly: AssemblyConfigurationAttribute("Release")>]
 do ()
 
@@ -14,6 +14,6 @@ module internal AssemblyVersionInformation =
     let [<Literal>] AssemblyTitle = "SynVer.Lib"
     let [<Literal>] AssemblyProduct = "SynVer"
     let [<Literal>] AssemblyDescription = "Syntactic (Semantic) Versioning for .NET libraries heavily inspired in elm-package (bump and diff)"
-    let [<Literal>] AssemblyVersion = "0.0.6"
-    let [<Literal>] AssemblyFileVersion = "0.0.6"
+    let [<Literal>] AssemblyVersion = "0.0.7"
+    let [<Literal>] AssemblyFileVersion = "0.0.7"
     let [<Literal>] AssemblyConfiguration = "Release"

--- a/src/SynVer.Lib/Compare.fs
+++ b/src/SynVer.Lib/Compare.fs
@@ -1,6 +1,4 @@
 module SynVer.Compare
-open System.Reflection
-open System
 type private Ns = Namespace
 type private T = SurfaceOfType
 type private M = Member

--- a/src/SynVer.Lib/Compare.fs
+++ b/src/SynVer.Lib/Compare.fs
@@ -18,19 +18,18 @@ let members (source:M list) (target: M list) =
 
 [<CompiledName("Types")>]
 let types (source:T list) (target: T list) =
-  let typ (t:T) = t.Type 
-  let setOfNames = List.map typ >> set
+  let setOfNames = List.map T.typ >> set
   let sourceSet = source |> setOfNames
   let targetSet = target |> setOfNames
   let maybeChanged = Set.intersect targetSet sourceSet
   let compareMembersForTyp t=
-    let withTyp = List.find (typ >> (=) t)
+    let withTyp = List.find (T.typ >> (=) t)
     let sourceT = source |> withTyp
     let targetT = target |> withTyp
     members sourceT.Members targetT.Members
   let changed = maybeChanged 
               |> Seq.map (fun t->t, compareMembersForTyp t ) 
-              |> Seq.filter (fun (_,c)-> not c.IsEmpty)
+              |> Seq.filter (snd >> AddedAndRemoved.isEmpty >> not)
               |> Map.ofSeq
   {
       Diff=diffSet sourceSet targetSet
@@ -41,21 +40,20 @@ let types (source:T list) (target: T list) =
 [<CompiledName("Packages")>]
 let packages (source: Package) (target:Package)=
   let namespaces (source:Ns list) (target:Ns list) =
-    let nameOf (ns:Ns) = ns.Namespace 
-    let setOfNames = List.map nameOf >> set
+    let setOfNames = List.map Ns.name >> set
     let sourceSet = source |> setOfNames
     let targetSet = target |> setOfNames
 
     let maybeChanged = Set.intersect targetSet sourceSet
     let compareTypesForNsWithName t=
-      let withName = List.find (nameOf >> (=) t)
+      let withName = List.find (Ns.name >> (=) t)
       let sourceT = source |> withName
       let targetT = target |> withName
       types sourceT.Types targetT.Types
 
     let changed = maybeChanged 
                 |> Seq.map (fun t->t, compareTypesForNsWithName t ) 
-                |> Seq.filter (fun (_,c)-> not c.IsEmpty)
+                |> Seq.filter (snd >> Changes.isEmpty >> not)
                 |> Map.ofSeq
     {
         Diff=diffSet sourceSet targetSet

--- a/src/SynVer.Lib/Decompile.fs
+++ b/src/SynVer.Lib/Decompile.fs
@@ -212,7 +212,7 @@ module Decompile =
         | false -> []
         | true ->
           t.Fields
-          //|> Seq.filter(fun x -> x.FieldType.IsEnum)
+          |> Seq.filter(fun x -> not x.IsSpecialName && not x.IsRuntimeSpecialName)
           |> Seq.map(fun x -> EnumValue(typ, x.Name, sprintf "%A" (x.Constant)))
           |> List.ofSeq
 

--- a/src/SynVer.Lib/Decompile.fs
+++ b/src/SynVer.Lib/Decompile.fs
@@ -1,0 +1,246 @@
+namespace SynVer
+
+open System
+open Mono.Cecil
+open Mono.Cecil
+
+module Decompile =
+  module CustomAttribute=
+    let typ (a:CustomAttribute)= a.AttributeType
+    let typeName a = (typ a).Name
+    let typeFullName a = (typ a).FullName
+  open Microsoft.FSharp.Core
+
+  let private _tagNetType (t: TypeDefinition) : NetType =
+      let debuggerAttr a=(CustomAttribute.typeName a).Contains("Debugger")
+      let serializableAttr a = CustomAttribute.typeFullName a = "System.SerializableAttribute"
+      let compilationMappingAttr a = CustomAttribute.typeName a = "CompilationMappingAttribute"
+      let structAttr a = CustomAttribute.typeName a = "StructAttribute"
+      let attrs = t.CustomAttributes
+                    |> Seq.filter( debuggerAttr >> not )
+                    |> Seq.filter( serializableAttr >> not )
+      
+      let compilationAttr = attrs |> Seq.tryFind compilationMappingAttr
+      let structAttr = attrs |> Seq.tryFind structAttr
+      let fromTypeFlags ()=
+          match t with
+            | _ when t.IsInterface ->
+              NetType.Interface
+            | _ when t.IsEnum ->
+              NetType.Enum
+            | _ when t.IsAbstract && t.IsClass && t.IsSealed ->
+              NetType.Static
+            | _ when t.IsValueType && not t.IsEnum && not t.IsPrimitive ->
+              NetType.Struct
+            | _ when t.IsAbstract ->
+              NetType.Abstract
+            | _ -> NetType.Class
+
+      match compilationAttr, structAttr with
+      | Some attr, _-> 
+          let h = 
+            attr.ConstructorArguments
+              |> Seq.map(fun x -> x.Value) 
+              |> Seq.cast<SourceConstructFlags>
+              |> Seq.head 
+          match h with
+          | SourceConstructFlags.Module     -> NetType.Module
+          | SourceConstructFlags.RecordType -> NetType.RecordType
+          | SourceConstructFlags.SumType    -> NetType.SumType
+          | _ -> fromTypeFlags()
+      | _ , Some _ ->NetType.Struct
+      | _ , _ -> fromTypeFlags()
+  let private memoize f =
+    let cache = new System.Collections.Concurrent.ConcurrentDictionary<'x, 'y>()
+    (fun (x:'x) ->
+        cache.GetOrAdd(x, System.Func<'x,'y>(f)))
+
+  [<CompiledName("TagNetType")>]
+  let tagNetType = memoize _tagNetType
+
+  [<CompiledName("ExportedTypes")>]
+  let exportedTypes (filename:string) : TypeDefinition list =
+    let r = ReaderParameters() 
+    let a = AssemblyDefinition.ReadAssembly (filename, r)
+    a.Modules 
+      |> Seq.map (fun m-> m.Types)
+      |> Seq.concat
+      |> Seq.toList
+  let rec internal typeFullName (t:TypeReference) =
+      let fullname =
+        match t.HasGenericParameters with
+          | false ->
+            match String.IsNullOrEmpty t.FullName with
+              | true -> sprintf "'%s" (t.Name.ToUpperInvariant())
+              | false -> t.FullName 
+          | true ->
+            let args =
+              t.GenericParameters
+              |> Seq.map typeFullName
+              |> Seq.reduce(sprintf "%s,%s")
+            let removeAfterTick (a:string)=
+                let i = a.IndexOf('`')
+                if i>1 then a.Substring(0, i)
+                else a
+            let name = 
+                if (not << String.IsNullOrEmpty) ( t.FullName ) then
+                    removeAfterTick t.FullName 
+                else 
+                    removeAfterTick t.Name
+            sprintf "%s<%s>" name args
+
+      let guid = Guid.NewGuid().ToString()
+      fullname.Replace("+Tags",guid).Replace('+','.').Replace(guid,"+Tags")
+
+  [<CompiledName("TypeToTyp")>]
+  let typeToTyp (t:TypeReference):Typ={ FullName=typeFullName t }
+  [<AutoOpen>]
+  module private ToMember=
+    type 'a Roc = System.Collections.ObjectModel.ReadOnlyCollection<'a>
+    type CatArg = CustomAttributeTypedArgument
+
+    let notNull value = 
+      if obj.ReferenceEquals(value, null) then None 
+      else Some value
+
+    let parameterToParameter (p:ParameterReference) :Parameter= { Type=typeToTyp p.ParameterType; Name=p.Name }
+    let parametersToParameter prms= prms |>Seq.map parameterToParameter |> List.ofSeq
+    let deconstructConstructor t (ctr:MethodDefinition) :ConstructorLike =
+      let params' = ctr.Parameters |> parametersToParameter
+      {Type=typeToTyp t; Parameters=params'}
+    let recordConstructor t ctr : Member=
+      RecordConstructor (deconstructConstructor t ctr)
+    let constructor' t ctr : Member=
+      Constructor (deconstructConstructor t ctr)
+    let isStatic b = match b with | true -> InstanceOrStatic.Static | false -> InstanceOrStatic.Instance
+
+    let event' (ei:EventDefinition) : Member=
+      let mi = ei.EventType.GetMethod("Invoke")
+      let params' = mi.GetParameters() |> parametersToParameter
+      Event {Type=typeToTyp mi.ReflectedType
+             Instance= isStatic mi.IsStatic 
+             Name= ei.Name
+             Parameters= params'
+             Result= typeToTyp mi.ReturnType}
+    let field t (fi:FieldDefinition) : Member=
+      Field {Type=typeToTyp t
+             Instance=isStatic fi.IsStatic
+             Name= fi.Name
+             Result= typeToTyp fi.FieldType}
+    let method' t (mi:MethodDefinition) : Member= 
+      let params' = mi.Parameters |> parametersToParameter
+      Method {Type=typeToTyp t
+              Instance= isStatic mi.IsStatic 
+              Name= mi.Name
+              Parameters= params'
+              Result= typeToTyp mi.ReturnType}
+    let property t (pi:PropertyDefinition) : Member= 
+      let static' =
+          match notNull (pi.GetMethod), notNull (pi.SetMethod) with
+          |  Some getMethod, _ -> getMethod.IsStatic
+          | _, Some setMethod -> setMethod.IsStatic
+          | _, _ -> true
+          
+
+      Property {Type=typeToTyp t
+                Instance=isStatic static'
+                Name= pi.Name
+                Result= typeToTyp pi.PropertyType}
+
+    let constructors (t: TypeDefinition): (ConstructorLike) seq=
+        let deconstructConstructor =deconstructConstructor t
+        t.Methods |> Seq.filter (fun m -> m.IsNewSlot)
+        //t.GetConstructors(bfs |> List.fold(( ||| )) BindingFlags.Instance)
+        |> Seq.sortBy(fun x -> x.Name, x.Parameters.Count)
+        |> Seq.map deconstructConstructor
+    let unionConstructors' t ctors :Member list=
+      ctors|> List.map (fun ctor-> UnionConstructor (t,ctor))
+
+    let toUnionCases (t:TypeReference) : Member list=
+      let tp = typeToTyp t
+      let mapNullOrItemToNull n = 
+              if String.IsNullOrEmpty n || n = "Item" then 
+                null
+              else
+                n
+      FSharpType.GetUnionCases(t)
+      |> Array.map(
+        fun x ->
+          let ps = x.GetFields()
+                |> Array.map(fun pi -> 
+                      Parameter.Create(typeToTyp pi.PropertyType, mapNullOrItemToNull pi.Name))
+                |> Array.toList
+          UnionCase (tp, x.Name, ps) //{ Name=x.Name; Fields=ps }
+      )
+      |> List.ofArray
+
+    let getTypeMember (t:Typ) (m:MemberReference) : Member list=
+      //let tag = tagNetType m.ReflectedType
+      let m' = m.Resolve()
+      // Handle cases like the Fsharp.Core does (and a bit more):
+      //
+      // https://github.com/Microsoft/visualfsharp/blob/master/src/fsharp/
+      //   FSharp.Core.Unittests/LibraryTestFx.fs#L103-L110
+      //
+      match m with
+        | MemberTypes.Constructor ->
+          let nameInfo = (m :?> ConstructorInfo)
+          match tag with
+            | NetType.RecordType ->[ (recordConstructor nameInfo)]
+            | __________ ->[ (constructor' nameInfo) ]
+        | MemberTypes.Event ->
+          [ (event' (m :?> EventInfo))]
+        | MemberTypes.Field -> 
+          [ (field (m :?> FieldInfo))]
+        | MemberTypes.Method ->
+          [ (method' (m :?> MethodInfo))]
+        | MemberTypes.NestedType ->
+          let nt = (m :?> Type)
+          match tag with
+            | NetType.SumType ->
+              [| nt |]
+              |> Array.collect (constructors [BindingFlags.NonPublic])
+              |> Array.toList
+              |> unionConstructors' t
+            | _ ->
+              // Already handled in `let types = ...`
+              []
+        | MemberTypes.Property ->
+          [ (property (m :?> PropertyInfo))]
+        | _ ->
+          let fullname = m.ReflectedType.FullName
+          failwith
+            (sprintf "not handled: (%A,%s,%A)" tag fullname m.MemberType)
+   
+  let enumValues (t:TypeDefinition) =
+      let typ = typeToTyp t
+      t.IsEnum |> function
+        | false -> []
+        | true ->
+          t.Fields
+          //|> Seq.filter(fun x -> x.FieldType.IsEnum)
+          |> Seq.map(fun x -> EnumValue(typ, x.Name, sprintf "%A" (x.Constant)))
+          |> List.ofSeq
+
+  [<CompiledName("GetTypeMembers")>]
+  let getTypeMembers (t:TypeDefinition) : Member list=
+    let t' = typeToTyp t
+    let netT = tagNetType t
+    //t.Methods
+    let l= List.collect (getTypeMember t') (t.Properties |> Seq.toList)
+    let l2= List.collect (getTypeMember t') (t.Fields |> Seq.toList)
+    match netT with
+    | NetType.SumType -> l @ l2 @ toUnionCases t
+    | NetType.Enum -> l @ l2 @ (enumValues t)
+    | _ -> l
+
+  /// Concrete type of a SumType, i.e. Foo and Bar when 
+  /// type SumType=Foo|Bar
+  [<CompiledName("IsSumType")>]
+  let isSumType (t: TypeDefinition): bool =
+        t.IsNested &&
+        (t.BaseType |> function
+           | null  -> false
+           | type' -> (tagNetType (type'.Resolve())) = NetType.SumType)
+
+

--- a/src/SynVer.Lib/Decompile.fs
+++ b/src/SynVer.Lib/Decompile.fs
@@ -237,4 +237,20 @@ module Decompile =
            | null  -> false
            | type' -> (tagNetType (type'.Resolve())) = NetType.SumType)
 
-
+  [<CompiledName("ReadAssembly")>]
+  let readAssembly (path:string)=
+    let r = ReaderParameters()
+    r.AssemblyResolver <- {
+      new DefaultAssemblyResolver()
+      with
+        override this.Resolve(name:AssemblyNameReference)=
+          try
+            base.Resolve(name)
+          with _->
+            // hack to avoid assembly load failure on Windows
+            if name.Name.Equals("FSharp.Core", StringComparison.OrdinalIgnoreCase) then 
+              AssemblyDefinition.ReadAssembly (typeof< FSharp.Core.FSharpTypeFunc>).Assembly.Location
+            else
+              null
+    }
+    AssemblyDefinition.ReadAssembly(path, r)

--- a/src/SynVer.Lib/FSharpType.fs
+++ b/src/SynVer.Lib/FSharpType.fs
@@ -1,0 +1,253 @@
+namespace SynVer
+
+open System
+open Mono.Cecil
+// port of selected parts of
+// https://github.com/fsharp/fsharp/blob/7ac8931b4595f0f30bc9b3bc8a094ecc69ccc443/src/fsharp/FSharp.Core/reflect.fs
+// to Mono.Cecil
+
+type BindingFlags=System.Reflection.BindingFlags
+module internal CustomAttribute=
+  let typ (a:CustomAttribute)= a.AttributeType
+  let typeName a = (typ a).Name
+  let typeFullName a = (typ a).FullName
+module internal TypeDefinition =
+  let getNestedType (n:string) (b:BindingFlags) (t:TypeDefinition)= //TODO: is binding flags possible?
+    t.NestedTypes |> Seq.tryFind (fun t' -> t'.Name = n)
+module internal AssemblyDefinition=
+  /// the assumption is that this does not fail, i.e. that the tests pick it up in that case
+  let getType (t:Type) (a:AssemblyDefinition) :TypeDefinition= 
+    match a.MainModule.Types |> Seq.tryFind (fun t'->t'.FullName = t.FullName) with
+    | Some t' -> t'
+    | None -> failwithf "Could not find '%s'" t.FullName 
+    
+module Impl=
+    let isNamedType(typ:TypeReference) = not (typ.IsArray || typ.IsByReference || typ.IsPointer)
+
+
+    let isCompilationMappingAttr a = CustomAttribute.typeName a = "CompilationMappingAttribute"
+    let getGenericTypeDefinition (ty:TypeReference) = 
+        failwithf "! %s" ty.FullName
+    
+    let equivHeadTypes (ty1:TypeReference) (ty2:TypeReference) = 
+        isNamedType(ty1) &&
+        if ty1.IsGenericInstance then 
+          ty2.IsGenericInstance && (getGenericTypeDefinition ty1).Equals(getGenericTypeDefinition ty2)
+        else 
+          ty1.Equals(ty2)
+
+    //let func = typedefof<(obj -> obj)>
+    
+    let fsharpAssembly =
+        let f = (typeof< FSharp.Core.FSharpTypeFunc>)
+        AssemblyDefinition.ReadAssembly f.Assembly.Location
+    let isOptionType typ = equivHeadTypes typ <| AssemblyDefinition.getType (typeof<int option>) fsharpAssembly 
+    let isFunctionType typ = equivHeadTypes typ <| AssemblyDefinition.getType (typeof<(int -> int)>) fsharpAssembly
+    let isListType typ = equivHeadTypes typ <| AssemblyDefinition.getType (typeof<int list>) fsharpAssembly
+    let getInstancePropertyInfo (typ: TypeDefinition,propName,bindingFlags) = 
+        typ.Properties |> Seq.tryFind (fun p->p.Name = propName && p.HasThis) //TODO: instancePropertyFlags ||| bindingFlags) 
+    let getInstancePropertyInfos (typ,names,bindingFlags) = 
+        names |> Array.choose (fun nm -> getInstancePropertyInfo (typ,nm,bindingFlags)) 
+    
+    let tryFindCompilationMappingAttribute (attrs:CustomAttribute[]) =
+      match attrs with
+      | null | [| |] -> None
+      | [| res |] ->
+        let sourceConstructFlags = res.Properties |> Seq.find (fun p->p.Name = "SourceConstructFlags") 
+        let sequenceNumber = res.Properties |> Seq.find (fun p->p.Name = "SequenceNumber")
+        let variantNumber = res.Properties |> Seq.find (fun p->p.Name = "VariantNumber")
+        //let a = (res :?> CompilationMappingAttribute) in Some (a.SourceConstructFlags, a.SequenceNumber, a.VariantNumber)
+        Some (sourceConstructFlags.Argument.Value :?>SourceConstructFlags, 
+              sequenceNumber.Argument.Value :?>int, 
+              variantNumber.Argument.Value :?>int)
+      | _ -> raise <| System.InvalidOperationException "multipleCompilationMappings"
+
+    let findCompilationMappingAttribute (attrs:CustomAttribute[]) =
+      match tryFindCompilationMappingAttribute attrs with
+      | None -> failwith "no compilation mapping attribute"
+      | Some a -> a
+    let tryFindCompilationMappingAttributeFromType (typ:TypeDefinition) = 
+        tryFindCompilationMappingAttribute ( typ.CustomAttributes |> Seq.filter isCompilationMappingAttr |> Seq.toArray)
+
+    let tryFindSourceConstructFlagsOfType (typ:TypeDefinition) = 
+      match tryFindCompilationMappingAttributeFromType typ with 
+      | None -> None
+      | Some (flags,_n,_vn) -> Some flags
+
+    let tryFindCompilationMappingAttributeFromMemberInfo (info:IMemberDefinition) = 
+        tryFindCompilationMappingAttribute ( info.CustomAttributes |> Seq.filter isCompilationMappingAttr |> Seq.toArray)
+        
+    let findCompilationMappingAttributeFromMemberInfo (info: IMemberDefinition) = findCompilationMappingAttribute ( info.CustomAttributes |> Seq.filter isCompilationMappingAttr |> Seq.toArray)
+    let sequenceNumberOfMember          (x: IMemberDefinition) = let (_,n,_) = findCompilationMappingAttributeFromMemberInfo x in n
+    let variantNumberOfMember           (x: IMemberDefinition) = let (_,_,vn) = findCompilationMappingAttributeFromMemberInfo x in vn
+
+    let isExceptionRepr (typ:TypeDefinition,bindingFlags) = 
+        match tryFindSourceConstructFlagsOfType(typ) with 
+        | None -> false 
+        | Some(flags) -> 
+          ((flags &&& SourceConstructFlags.KindMask) = SourceConstructFlags.Exception) &&
+          // We see private representations only if BindingFlags.NonPublic is set
+          (if (flags &&& SourceConstructFlags.NonPublicRepresentation) <> enum(0) then 
+              (bindingFlags &&& BindingFlags.NonPublic) <> enum(0)
+           else 
+              true)
+              
+    let isFieldProperty (prop : PropertyDefinition) =
+        match tryFindCompilationMappingAttributeFromMemberInfo(prop) with
+        | None -> false
+        | Some (flags,_n,_vn) -> (flags &&& SourceConstructFlags.KindMask) = SourceConstructFlags.Field
+
+    let isUnionType (typ:TypeDefinition,bindingFlags:BindingFlags) = 
+        isOptionType typ || 
+        isListType typ || 
+        match tryFindSourceConstructFlagsOfType(typ) with 
+        | None -> false
+        | Some(flags) ->
+          (flags &&& SourceConstructFlags.KindMask) = SourceConstructFlags.SumType &&
+          // We see private representations only if BindingFlags.NonPublic is set
+          (if (flags &&& SourceConstructFlags.NonPublicRepresentation) <> enum(0) then 
+              (bindingFlags &&& BindingFlags.NonPublic) <> enum(0)
+           else 
+              true)
+    let unionTypeOfUnionCaseType (typ:TypeDefinition,bindingFlags) = 
+        let rec get (typ:TypeDefinition) = if isUnionType (typ,bindingFlags) then typ else match typ.BaseType with null -> typ | b -> get <| b.Resolve()
+        get typ
+    // Check the base type - if it is also an F# type then
+    // for the moment we know it is a Discriminated Union
+    let isConstructorRepr (typ:TypeDefinition,bindingFlags:BindingFlags) = 
+        let rec get (typ:TypeDefinition) = isUnionType (typ,bindingFlags) || match typ.BaseType with null -> false | b -> get (b.Resolve())
+        get typ 
+    let rec isClosureRepr (typ:TypeReference) = 
+        isFunctionType typ || 
+        (match typ.Resolve().BaseType with null -> false | bty -> isClosureRepr bty)
+    let getTypeOfReprType (typ:TypeDefinition,bindingFlags)= 
+        if isExceptionRepr(typ,bindingFlags) then typ.BaseType.Resolve()
+        elif isConstructorRepr(typ,bindingFlags) then unionTypeOfUnionCaseType(typ,bindingFlags)
+        elif isClosureRepr(typ) then 
+          let rec get (typ:TypeDefinition) = if isFunctionType typ then typ else match typ.BaseType with null -> typ | b -> get <| b.Resolve()
+          get typ 
+        else typ
+        
+    let getUnionTypeTagNameMap (typ:TypeDefinition,bindingFlags) = 
+        let maybeEnumTyp =TypeDefinition.getNestedType "Tags" bindingFlags typ
+        // Unions with a singleton case do not get a Tags type (since there is only one tag), hence enumTyp may be null in this case
+        match maybeEnumTyp with
+        | None -> 
+            typ.Methods |> Seq.filter (fun m->m.IsStatic)// TODO?: filter on bindingFlags 
+            |> Seq.choose (fun minfo -> 
+                match tryFindCompilationMappingAttributeFromMemberInfo(minfo) with
+                | None -> None
+                | Some (flags,n,_vn) -> 
+                    if (flags &&& SourceConstructFlags.KindMask) = SourceConstructFlags.UnionCase then 
+                        let nm = minfo.Name 
+                        // chop "get_" or  "New" off the front 
+                        let nm = 
+                            if not (isListType typ) && not (isOptionType typ) then 
+                                if   nm.Length > 4 && nm.[0..3] = "get_" then nm.[4..] 
+                                elif nm.Length > 3 && nm.[0..2] = "New" then nm.[3..]
+                                else nm
+                            else nm
+                        Some (n, nm)
+                    else
+                        None) 
+        | Some enumTyp -> 
+            enumTyp.Fields |> Seq.filter (fun f->f.IsStatic)//TODO?: filter on bindingFlags 
+            |> Seq.filter (fun f -> f.IsStatic && f.IsLiteral) 
+            |> Seq.sortWith (fun f1 f2 -> compare (f1.Constant :?> int) (f2.Constant :?> int))
+            |> Seq.map (fun tagfield -> (tagfield.Constant :?> int),tagfield.Name)
+    let getUnionCaseTyp (typ: TypeDefinition, tag: int, bindingFlags) = 
+        let tagFields = getUnionTypeTagNameMap(typ,bindingFlags) |> Seq.toArray
+        let tagField = tagFields |> Array.pick (fun (i,f) -> if i = tag then Some f else None)
+        if tagFields.Length = 1 then 
+            typ
+        else
+            // special case: two-cased DU annotated with CompilationRepresentation(UseNullAsTrueValue)
+            // in this case it will be compiled as one class: return self type for non-nullary case and null for nullary
+            let isTwoCasedDU =
+                if tagFields.Length = 2 then
+                    (*match typ.GetCustomAttributes(typeof<CompilationRepresentationAttribute>, false) with
+                    | [|:? CompilationRepresentationAttribute as attr|] -> 
+                        (attr.Flags &&& CompilationRepresentationFlags.UseNullAsTrueValue) = CompilationRepresentationFlags.UseNullAsTrueValue
+                    | _ -> false*)
+                    failwith "!"
+                else
+                    false
+            if isTwoCasedDU then
+                typ
+            else
+            let casesTyp = typ //getUnionCasesTyp (typ, bindingFlags)
+            //let caseTyp =  //bindingFlags) // if this is null then the union is nullary
+            match casesTyp.NestedTypes |> Seq.tryFind (fun ct->ct.Name=tagField) with 
+            | None -> null
+            | Some caseTyp when caseTyp.IsGenericInstance ->
+                failwithf "! %s" caseTyp.Name 
+                //caseTyp.MakeGenericType(casesTyp.GetGenericArguments())
+            | Some caseTyp -> caseTyp
+    let fieldsPropsOfUnionCase(typ:TypeDefinition, tag:int, bindingFlags) =
+        if isOptionType typ then 
+            match tag with 
+            | 0 (* None *) -> getInstancePropertyInfos (typ,[| |],bindingFlags) 
+            | 1 (* Some *) -> getInstancePropertyInfos (typ,[| "Value" |] ,bindingFlags) 
+            | _ -> failwith "fieldsPropsOfUnionCase"
+        elif isListType typ then 
+            match tag with 
+            | 0 (* Nil *)  -> getInstancePropertyInfos (typ,[| |],bindingFlags) 
+            | 1 (* Cons *) -> getInstancePropertyInfos (typ,[| "Head"; "Tail" |],bindingFlags) 
+            | _ -> failwith "fieldsPropsOfUnionCase"
+        else
+            // Lookup the type holding the fields for the union case
+            let caseTyp = getUnionCaseTyp (typ, tag, bindingFlags)
+            let caseTyp = match caseTyp with null ->  typ | _ -> caseTyp
+            caseTyp.Properties |> Seq.filter (fun p->p.HasThis)//.GetProperties(instancePropertyFlags ||| bindingFlags) 
+            |> Seq.filter isFieldProperty
+            |> Seq.filter (fun prop -> variantNumberOfMember prop = tag)
+            |> Seq.sortWith (fun p1 p2 -> compare (sequenceNumberOfMember p1) (sequenceNumberOfMember p2))
+            |> Seq.toArray
+    let getUnionTagConverter (typ:TypeDefinition,bindingFlags) = 
+        if isOptionType typ then (fun tag -> match tag with 0 -> "None" | 1 -> "Some" | _ -> invalidArg "tag" "outOfRange")
+        elif isListType typ then (fun tag -> match tag with  0 -> "Empty" | 1 -> "Cons" | _ -> invalidArg "tag" "outOfRange")
+        else 
+          let tagfieldmap = getUnionTypeTagNameMap (typ,bindingFlags) |> Map.ofSeq
+          (fun tag -> tagfieldmap.[tag])                
+[<Sealed>]
+type UnionCaseInfo(typ: TypeDefinition, tag:int) =
+    // Cache the tag -> name map
+    let mutable names = None
+    //let getMethInfo() = Impl.getUnionCaseConstructorMethod (typ, tag, BindingFlags.Public ||| BindingFlags.NonPublic) 
+    member __.Name = 
+        match names with 
+        | None -> (let conv = Impl.getUnionTagConverter (typ,BindingFlags.Public ||| BindingFlags.NonPublic) in names <- Some conv; conv tag)
+        | Some conv -> conv tag
+        
+    member __.DeclaringType = typ
+
+    member __.GetFields() = 
+        let props = Impl.fieldsPropsOfUnionCase(typ,tag,BindingFlags.Public ||| BindingFlags.NonPublic) 
+        props
+    
+
+    (* member __.GetCustomAttributes() = getMethInfo().GetCustomAttributes(false) 
+    *)
+    
+    (* member __.GetCustomAttributes(attributeType) = getMethInfo().GetCustomAttributes(attributeType,false) 
+    *)
+
+    (* member __.GetCustomAttributesData() = getMethInfo().CustomAttributes |> Seq.toArray :> System.Collections.Generic.IList<_>
+    *)
+    member __.Tag = tag
+    //override x.ToString() = typ.Name + "." + x.Name
+    override x.GetHashCode() = typ.GetHashCode() + tag
+    override __.Equals(obj:obj) = 
+        match obj with 
+        | :? UnionCaseInfo as uci -> uci.DeclaringType = typ && uci.Tag = tag
+        | _ -> false
+        
+[<AbstractClass; Sealed>]
+type FSharpType = 
+
+    static member GetUnionCases (unionType:TypeDefinition,?bindingFlags) = 
+        let bindingFlags = defaultArg bindingFlags BindingFlags.Public
+        //Impl.checkNonNull "unionType" unionType
+        let unionType = Impl.getTypeOfReprType (unionType ,bindingFlags)
+        //Impl.checkUnionType(unionType,bindingFlags);
+        Impl.getUnionTypeTagNameMap(unionType,bindingFlags) |> Seq.mapi (fun i _ -> UnionCaseInfo(unionType,i)) |> Seq.toArray

--- a/src/SynVer.Lib/FSharpType.fs
+++ b/src/SynVer.Lib/FSharpType.fs
@@ -78,11 +78,16 @@ module Impl=
       match attrs with
       | null | [| |] -> None
       | [| res |] ->
-        
+        // https://github.com/fsharp/fsharp/blob/3ef054469387449dc7bd6f151960825235fe491c/src/fsharp/FSharp.Core/prim-types.fs#L220-L223
         match res.ConstructorArguments |> Seq.toList with
-        | [sourceConstructFlags] -> Some (sourceConstructFlags.Value :?>SourceConstructFlags, 0, 0)
-        | [sourceConstructFlags; sequenceNumber] -> Some (sourceConstructFlags.Value :?>SourceConstructFlags, sequenceNumber.Value :?>int, 0)
-        | [sourceConstructFlags;variantNumber; sequenceNumber] -> Some (sourceConstructFlags.Value :?>SourceConstructFlags, sequenceNumber.Value :?>int, variantNumber.Value:?>int)
+        | [sourceConstructFlags] ->
+          Some (sourceConstructFlags.Value :?>SourceConstructFlags, 0, 0)
+        | [sourceConstructFlags; sequenceNumber] when sourceConstructFlags.Type.Name = "SourceConstructFlags" ->
+          Some (sourceConstructFlags.Value :?>SourceConstructFlags, sequenceNumber.Value :?>int, 0)
+        | [_; _] ->
+          Some (SourceConstructFlags.None, 0, 0)
+        | [sourceConstructFlags;variantNumber; sequenceNumber] ->
+          Some (sourceConstructFlags.Value :?>SourceConstructFlags, sequenceNumber.Value :?>int, variantNumber.Value:?>int)
         | _ -> raise <| System.InvalidOperationException "constructor"
       | _ -> raise <| System.InvalidOperationException "multipleCompilationMappings"
     let tryFindCompilationRepresentationAttribute (attrs:CustomAttribute[]) =

--- a/src/SynVer.Lib/FSharpType.fs
+++ b/src/SynVer.Lib/FSharpType.fs
@@ -64,8 +64,7 @@ module Impl=
     //let func = typedefof<(obj -> obj)>
     
     let fsharpAssembly =
-        let f = (typeof< FSharp.Core.FSharpTypeFunc>)
-        AssemblyDefinition.ReadAssembly f.Assembly.Location
+        AssemblyDefinition.ReadAssembly (typeof< FSharp.Core.FSharpTypeFunc>).Assembly.Location
     let isOptionType typ = equivHeadTypes typ <| AssemblyDefinition.getType (typedefof<_ option>) fsharpAssembly 
     let isFunctionType typ = equivHeadTypes typ <| AssemblyDefinition.getType (typedefof<(_-> _)>) fsharpAssembly
     let isListType typ = equivHeadTypes typ <| AssemblyDefinition.getType (typedefof<_ list>) fsharpAssembly

--- a/src/SynVer.Lib/Models.fs
+++ b/src/SynVer.Lib/Models.fs
@@ -48,7 +48,7 @@ with
   static member private WhenStatic (flag:InstanceOrStatic) (typ:Typ) : string =
     match flag with
       | InstanceOrStatic.Static -> typ.FullName
-      | InstanceOrStatic.Instance -> sprintf "(Instance/Inheritance of %s)" typ.FullName
+      | InstanceOrStatic.Instance -> sprintf "(Instance of %s)" typ.FullName
       | _ -> failwith "!"
 
   static member private Parameters (prms:Parameter list) : string =

--- a/src/SynVer.Lib/Models.fs
+++ b/src/SynVer.Lib/Models.fs
@@ -187,6 +187,7 @@ with
 
   static member IsSumType (x:SurfaceOfType) = x.SumType
   static member GetNetType (x:SurfaceOfType) = x.NetType
+  [<CompiledName("Typ")>]static member typ (x:SurfaceOfType) = x.Type
 
 type Namespace=
     {
@@ -195,7 +196,7 @@ type Namespace=
     }
 with
   override x.ToString()=sprintf "%A" x
-
+  [<CompiledName("Name")>]static member name (n:Namespace) = n.Namespace
 type Package=
     {
       Namespaces: Namespace list
@@ -211,7 +212,8 @@ type 'a AddedAndRemoved when 'a:comparison=
 with
   override x.ToString()=sprintf "%A" x
   member this.IsEmpty=this.Added.IsEmpty && this.Removed.IsEmpty
-
+module AddedAndRemoved=
+  let isEmpty (c:AddedAndRemoved<_>)=c.IsEmpty
 type Changes<'t,'m when 't:comparison>=
     {
         Diff: AddedAndRemoved<'t>
@@ -220,3 +222,5 @@ type Changes<'t,'m when 't:comparison>=
 with
   override x.ToString()=sprintf "%A" x
   member this.IsEmpty=this.Diff.IsEmpty && this.Changes.IsEmpty
+module Changes=
+  let isEmpty (c:Changes<_,_>)=c.IsEmpty

--- a/src/SynVer.Lib/Reflect.fs
+++ b/src/SynVer.Lib/Reflect.fs
@@ -3,7 +3,6 @@ namespace SynVer
 open Microsoft.FSharp.Reflection
 open System
 open System.Reflection
-open Microsoft.FSharp.Reflection
  
 module Reflect =
   type private CAtDat = CustomAttributeData

--- a/src/SynVer.Lib/Reflect.fs
+++ b/src/SynVer.Lib/Reflect.fs
@@ -122,7 +122,7 @@ module Reflect =
     let event' (ei:EventInfo) : Member=
       let mi = ei.EventHandlerType.GetMethod("Invoke")
       let params' = mi.GetParameters() |> parametersToParameter
-      Event {Type=typeToTyp mi.ReflectedType
+      Event {Type=typeToTyp ei.DeclaringType
              Instance= isStatic mi.IsStatic 
              Name= ei.Name
              Parameters= params'
@@ -185,20 +185,19 @@ module Reflect =
       // https://github.com/Microsoft/visualfsharp/blob/master/src/fsharp/
       //   FSharp.Core.Unittests/LibraryTestFx.fs#L103-L110
       //
-      match m.MemberType with
-        | MemberTypes.Constructor ->
-          let nameInfo = (m :?> ConstructorInfo)
+      match m with
+        | :? ConstructorInfo as nameInfo ->
           match tag with
             | NetType.RecordType ->[ (recordConstructor nameInfo)]
-            | __________ ->[ (constructor' nameInfo) ]
-        | MemberTypes.Event ->
-          [ (event' (m :?> EventInfo))]
-        | MemberTypes.Field -> 
-          [ (field (m :?> FieldInfo))]
-        | MemberTypes.Method ->
-          [ (method' (m :?> MethodInfo))]
-        | MemberTypes.NestedType ->
-          let nt = (m :?> Type)
+            | __________ ->[ constructor' nameInfo ]
+        | :? EventInfo as e -> [ event' e ]
+        | :? FieldInfo as f -> [ field f ]
+        | :? MethodInfo as m' ->
+            if m'.IsSpecialName then
+                []
+            else 
+                [ method' m' ]
+        | :? Type as nt ->
           match tag with
             | NetType.SumType ->
               [| nt |]
@@ -208,8 +207,8 @@ module Reflect =
             | _ ->
               // Already handled in `let types = ...`
               []
-        | MemberTypes.Property ->
-          [ (property (m :?> PropertyInfo))]
+        | :? PropertyInfo as p->
+          [ property p]
         | _ ->
           let fullname = m.ReflectedType.FullName
           failwith
@@ -229,7 +228,9 @@ module Reflect =
   let getTypeMembers (t:Type) : Member list=
     let t' = typeToTyp t
     let netT = tagNetType t
-    let l= List.collect (getTypeMember t') (t.GetMembers()|> Array.toList)
+    let members = t.GetMembers(BindingFlags.Instance ||| BindingFlags.Static ||| BindingFlags.Public||| BindingFlags.DeclaredOnly ) |> Array.toList
+    //let events = t.GetEvents(BindingFlags.Instance ||| BindingFlags.Static ||| BindingFlags.Public||| BindingFlags.DeclaredOnly) |> Array.toList
+    let l= List.collect (getTypeMember t') members
     match netT with
     | NetType.SumType -> l @ toUnionCases t
     | NetType.Enum -> l @ (enumValues t)

--- a/src/SynVer.Lib/SurfaceArea.fs
+++ b/src/SynVer.Lib/SurfaceArea.fs
@@ -163,7 +163,7 @@ let private sort' (x: string): string =
    x.Replace("Removed: ", System.String.Empty)
     .Replace("Added: ", System.String.Empty)
     .Replace("new ", System.String.Empty)
-    .Replace("(Instance/Inheritance of ", System.String.Empty)
+    .Replace("(Instance of ", System.String.Empty)
     .Replace("( ", System.String.Empty)
     .Replace("{ ", System.String.Empty)
 

--- a/src/SynVer.Lib/SurfaceArea.fs
+++ b/src/SynVer.Lib/SurfaceArea.fs
@@ -1,8 +1,5 @@
 module SynVer.SurfaceArea
 open System
-//open Reflect
-open System.IO
-open System.Security.Cryptography
 open Mono.Cecil
 
 /// Get the surface of a type

--- a/src/SynVer.Lib/SynVer.Lib.fsproj
+++ b/src/SynVer.Lib/SynVer.Lib.fsproj
@@ -41,6 +41,7 @@
     <Compile Include="Serialization.fs" />
     <Compile Include="Lson.fs" />
     <Compile Include="Reflect.fs" />
+    <Compile Include="FSharpType.fs" />
     <Compile Include="Decompile.fs" />
     <Compile Include="Compare.fs" />
     <Compile Include="SurfaceArea.fs" />

--- a/src/SynVer.Lib/SynVer.Lib.fsproj
+++ b/src/SynVer.Lib/SynVer.Lib.fsproj
@@ -41,11 +41,13 @@
     <Compile Include="Serialization.fs" />
     <Compile Include="Lson.fs" />
     <Compile Include="Reflect.fs" />
+    <Compile Include="Decompile.fs" />
     <Compile Include="Compare.fs" />
     <Compile Include="SurfaceArea.fs" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="FSharp.Core" Version="4.3.*" />
+    <PackageReference Include="ICSharpCode.Decompiler" Version="3.*" />
   </ItemGroup>
   <Import Project="..\..\.paket\Paket.Restore.targets" />
 </Project>

--- a/src/SynVer/AssemblyInfo.fs
+++ b/src/SynVer/AssemblyInfo.fs
@@ -5,8 +5,8 @@ open System.Reflection
 [<assembly: AssemblyTitleAttribute("SynVer")>]
 [<assembly: AssemblyProductAttribute("SynVer")>]
 [<assembly: AssemblyDescriptionAttribute("Syntactic (Semantic) Versioning for .NET libraries heavily inspired in elm-package (bump and diff)")>]
-[<assembly: AssemblyVersionAttribute("0.0.6")>]
-[<assembly: AssemblyFileVersionAttribute("0.0.6")>]
+[<assembly: AssemblyVersionAttribute("0.0.7")>]
+[<assembly: AssemblyFileVersionAttribute("0.0.7")>]
 [<assembly: AssemblyConfigurationAttribute("Release")>]
 do ()
 
@@ -14,6 +14,6 @@ module internal AssemblyVersionInformation =
     let [<Literal>] AssemblyTitle = "SynVer"
     let [<Literal>] AssemblyProduct = "SynVer"
     let [<Literal>] AssemblyDescription = "Syntactic (Semantic) Versioning for .NET libraries heavily inspired in elm-package (bump and diff)"
-    let [<Literal>] AssemblyVersion = "0.0.6"
-    let [<Literal>] AssemblyFileVersion = "0.0.6"
+    let [<Literal>] AssemblyVersion = "0.0.7"
+    let [<Literal>] AssemblyFileVersion = "0.0.7"
     let [<Literal>] AssemblyConfiguration = "Release"

--- a/src/SynVer/Program.fs
+++ b/src/SynVer/Program.fs
@@ -30,7 +30,7 @@ let (|AssemblyFile|LsonFile|Other|) (maybeFile:string) =
 
 let loadAssembly f =
   try
-    AssemblyDefinition.ReadAssembly (Path.GetFullPath f)
+    Decompile.readAssembly (Path.GetFullPath f)
     |> Ok
   with ex ->
     (sprintf "Failed to load assembly %s due to %s\n%s" f ex.Message ex.StackTrace) 

--- a/src/SynVer/Program.fs
+++ b/src/SynVer/Program.fs
@@ -8,6 +8,7 @@ open Mono.Cecil
 
 type CLIArguments =
     | Surface_of of path:string
+    | Decompile
     | Output of path:string
     | Diff of source:string * target:string
     | Bump of version:string * source:string * target:string
@@ -27,17 +28,19 @@ let (|AssemblyFile|LsonFile|Other|) (maybeFile:string) =
   | f, true when f.EndsWith(".lson") -> LsonFile
   | f, true when f.EndsWith(".dll") -> AssemblyFile
   | f, _  -> Other
+type 'a IAssemblyInterpreter=interface
+  abstract member ReadAssembly: string->'a
+  abstract member OfAssembly: 'a->Package
+end
 
-let loadAssembly f =
+let inline loadAssembly f readAssembly=
   try
-    Decompile.readAssembly (Path.GetFullPath f)
+    readAssembly (Path.GetFullPath f)
     |> Ok
   with ex ->
     (sprintf "Failed to load assembly %s due to %s\n%s" f ex.Message ex.StackTrace) 
     |> Error
-
-
-let getSurfaceAreaOf (f:string): Result<Package,string>=
+let getSurfaceAreaOf (f:string) (i:IAssemblyInterpreter<_>): Result<Package,string>=
   match f with
   | LsonFile ->
     let res = File.ReadAllText f
@@ -46,13 +49,13 @@ let getSurfaceAreaOf (f:string): Result<Package,string>=
     | Some p -> Ok p
     | None -> Error "Couldn't deserialize"
   | AssemblyFile -> 
-        loadAssembly f
-        |> Result.map SurfaceArea.ofAssemblyDefinition
+        loadAssembly f i.ReadAssembly
+        |> Result.map i.OfAssembly
   | Other -> Error "No dll or lson specified"
 
-
-let getDiff released modified : Result<string,string>=
-    let maybeReleased,maybeModified= getSurfaceAreaOf released, getSurfaceAreaOf modified
+let getDiff released modified (i:IAssemblyInterpreter<_>): Result<string,string>=
+    let maybeReleased,maybeModified= getSurfaceAreaOf released i,
+                                     getSurfaceAreaOf modified i
     match maybeReleased,maybeModified with
     | Ok released, Ok modified ->
         let changes =  SurfaceArea.diff released modified
@@ -66,9 +69,10 @@ let getDiff released modified : Result<string,string>=
         
         Error (String.Join(Environment.NewLine, errors) )
 
-let getBump version released modified : Result<string*Version,string>=
-    let maybeReleased,maybeModified= getSurfaceAreaOf released, getSurfaceAreaOf modified
-    match maybeReleased,maybeModified with
+let getBump version released modified (i:IAssemblyInterpreter<_>): Result<string*Version,string>=
+    let maybeReleased, maybeModified= getSurfaceAreaOf released i, getSurfaceAreaOf modified i
+
+    match maybeReleased, maybeModified with
     | Ok released, Ok modified ->
         SurfaceArea.bump version released modified
         |> Ok
@@ -79,7 +83,14 @@ let getBump version released modified : Result<string*Version,string>=
             |> List.toArray
         
         Error (String.Join(Environment.NewLine, errors) )
-
+let decompiler = { new IAssemblyInterpreter<AssemblyDefinition> with
+                   member __.ReadAssembly f = Decompile.readAssembly f
+                   member __.OfAssembly a = SurfaceArea.ofAssemblyDefinition a
+                 }
+let reflector = { new IAssemblyInterpreter<Assembly> with
+                  member __.ReadAssembly f = Assembly.LoadFile f
+                  member __.OfAssembly a = SurfaceArea.ofAssembly a
+                }
 [<EntryPoint>]
 let main argv = 
     let parser = ArgumentParser.Create<CLIArguments>(programName = "synver.exe")
@@ -101,26 +112,29 @@ let main argv =
         let maybeBump = results.TryGetResult(<@ Bump @>)
         let maybeMagnitude = results.TryGetResult(<@ Magnitude @>)
         let maybeOutput = results.TryGetResult(<@ Output @>)
+        let decompile = results.TryGetResult(<@ Decompile @>) |> Option.map (fun _->true) |> Option.defaultValue false
 
         match maybeFile, maybeDiff, maybeMagnitude, maybeBump with
         | Some file, None, None, None ->
-            loadAssembly file
-            |> Result.map (
-                SurfaceArea.ofAssemblyDefinition 
-                >> Lson.serialize
-            )
+            if decompile then
+              loadAssembly file Decompile.readAssembly
+              |> Result.map (SurfaceArea.ofAssemblyDefinition >> Lson.serialize)
+            else
+              loadAssembly file Assembly.LoadFile
+              |> Result.map (SurfaceArea.ofAssembly>> Lson.serialize)
         | None, Some (released, modified), None, None ->
-            getDiff released modified
+          if decompile then getDiff released modified decompiler
+          else getDiff released modified reflector
         | None, None, Some (released,modified), None ->
-            getBump "0.0.0" released modified
-            |> function 
-                | Ok (_,version)->version.ToString() |>Ok
-                | Error a->Error a
+          let res =
+            if decompile then getBump "0.0.0" released modified decompiler
+            else getBump "0.0.0" released modified reflector
+          res |> Result.map (snd>>string)
         | None, None, None, Some (version,released,modified) ->
-            getBump version released modified
-            |> function 
-                | Ok (version,_)->version |>Ok
-                | Error a->Error a
+          let res =
+            if decompile then getBump version released modified decompiler
+            else getBump version released modified reflector
+          res |> Result.map fst
         | _,_,_,_ ->
             Error(parser.PrintUsage())
         |> (fun res-> 

--- a/tests/ExampleProjects/src/Fsharp2.txt
+++ b/tests/ExampleProjects/src/Fsharp2.txt
@@ -6,21 +6,21 @@
                 System.Void
                 -> SpiseMisu.MyClassWithCLIEvent
 
-        - (Instance/Inheritance of SpiseMisu.MyClassWithCLIEvent).Event1.Add : 
+        - (Instance of SpiseMisu.MyClassWithCLIEvent).Event1.Add : 
                 sender:System.Object * args:System.Tuple<SpiseMisu.MyClassWithCLIEvent,System.Object>
                 -> System.Void
 
-        - (Instance/Inheritance of SpiseMisu.MyClassWithCLIEvent).TestEvent : 
+        - (Instance of SpiseMisu.MyClassWithCLIEvent).TestEvent : 
                 arg:System.Object
                 -> System.Void
 
         
 * SpiseMisu.Struct
 
-        + (Instance/Inheritance of SpiseMisu.Struct).Baz : 
+        + (Instance of SpiseMisu.Struct).Baz : 
                 System.Int32
 
-        + (Instance/Inheritance of SpiseMisu.Struct).Qux : 
+        + (Instance of SpiseMisu.Struct).Qux : 
                 System.Int32
 
         

--- a/tests/ExampleProjects/src/Fsharp2.txt
+++ b/tests/ExampleProjects/src/Fsharp2.txt
@@ -1,41 +1,17 @@
 * SpiseMisu.MyClassWithCLIEvent
 
-        - (Instance/Inheritance of FSharpHandler<System.Tuple<SpiseMisu.MyClassWithCLIEvent,System.Object>>).Event1.Add : 
-                sender:System.Object * args:System.Tuple<SpiseMisu.MyClassWithCLIEvent,System.Object>
-                -> System.Void
-
         Removed: SpiseMisu.MyClassWithCLIEvent (.NET type: Class and base: System.Object)
 
         - new SpiseMisu.MyClassWithCLIEvent : 
                 System.Void
                 -> SpiseMisu.MyClassWithCLIEvent
 
-        - (Instance/Inheritance of SpiseMisu.MyClassWithCLIEvent).Equals : 
-                obj:System.Object
-                -> System.Boolean
-
-        - (Instance/Inheritance of SpiseMisu.MyClassWithCLIEvent).GetHashCode : 
-                System.Void
-                -> System.Int32
-
-        - (Instance/Inheritance of SpiseMisu.MyClassWithCLIEvent).GetType : 
-                System.Void
-                -> System.Type
+        - (Instance/Inheritance of SpiseMisu.MyClassWithCLIEvent).Event1.Add : 
+                sender:System.Object * args:System.Tuple<SpiseMisu.MyClassWithCLIEvent,System.Object>
+                -> System.Void
 
         - (Instance/Inheritance of SpiseMisu.MyClassWithCLIEvent).TestEvent : 
                 arg:System.Object
-                -> System.Void
-
-        - (Instance/Inheritance of SpiseMisu.MyClassWithCLIEvent).ToString : 
-                System.Void
-                -> System.String
-
-        - (Instance/Inheritance of SpiseMisu.MyClassWithCLIEvent).add_Event1 : 
-                handler:FSharpHandler<System.Tuple<SpiseMisu.MyClassWithCLIEvent,System.Object>>
-                -> System.Void
-
-        - (Instance/Inheritance of SpiseMisu.MyClassWithCLIEvent).remove_Event1 : 
-                handler:FSharpHandler<System.Tuple<SpiseMisu.MyClassWithCLIEvent,System.Object>>
                 -> System.Void
 
         
@@ -46,14 +22,6 @@
 
         + (Instance/Inheritance of SpiseMisu.Struct).Qux : 
                 System.Int32
-
-        + (Instance/Inheritance of SpiseMisu.Struct).get_Baz : 
-                System.Void
-                -> System.Int32
-
-        + (Instance/Inheritance of SpiseMisu.Struct).get_Qux : 
-                System.Void
-                -> System.Int32
 
         
 * SpiseMisu.UnionPrime

--- a/tests/SynVer.Tests/DecompileAssemblyTests.fs
+++ b/tests/SynVer.Tests/DecompileAssemblyTests.fs
@@ -18,7 +18,8 @@ let assertAssemblyDefinitionMatchesAssembly assemblyDef assembly
   =
     let surfaceDef = SurfaceArea.ofAssemblyDefinition assemblyDef
     let surface = SurfaceArea.ofAssembly assembly
-    Expect.equal surfaceDef surface (assemblyDef.ToString())
+    let comparison = Compare.packages surface surfaceDef
+    Expect.equal surfaceDef surface (sprintf "\n\n\n%A\n\n\n" comparison)
 [<Tests>]
 let tests =
   testList "Read assembly definition tests" [    

--- a/tests/SynVer.Tests/DecompileAssemblyTests.fs
+++ b/tests/SynVer.Tests/DecompileAssemblyTests.fs
@@ -1,0 +1,77 @@
+module SynVer.DecompileAssemblyTests
+open SynVer
+open Expecto
+
+open TestHelper
+module CT= CecilTestAssemblies
+module T= TestAssemblies
+
+let assertCanSerializeAndDeserialize assembly
+  =
+    let surface = SurfaceArea.ofAssemblyDefinition assembly
+    let deserialized 
+        = surface
+          |> Lson.serialize
+          |> Lson.deserialize
+    Expect.equal surface deserialized (assembly.ToString())
+let assertAssemblyDefinitionMatchesAssembly assemblyDef assembly 
+  =
+    let surfaceDef = SurfaceArea.ofAssemblyDefinition assemblyDef
+    let surface = SurfaceArea.ofAssembly assembly
+    Expect.equal surfaceDef surface (assemblyDef.ToString())
+[<Tests>]
+let tests =
+  testList "Read assembly definition tests" [    
+    test "csharp can be serialized and deserialized" {
+      assertCanSerializeAndDeserialize CT.csharp
+    }
+    test "csharp2 can be serialized and deserialized" {
+      assertCanSerializeAndDeserialize CT.csharp2
+    }
+    test "enum can be serialized and deserialized" {
+      assertCanSerializeAndDeserialize CT.enum
+    }
+    test "enum2 can be serialized and deserialized" {
+      assertCanSerializeAndDeserialize CT.enum2
+    }
+    test "enum3 can be serialized and deserialized" {
+      assertCanSerializeAndDeserialize CT.enum3
+    }
+    
+    
+    test "csharp can be read by both cecil and reflection" {
+      assertAssemblyDefinitionMatchesAssembly CT.csharp T.csharp
+    }
+    test "csharp2 can be read by both cecil and reflection" {
+      assertAssemblyDefinitionMatchesAssembly CT.csharp2 T.csharp2
+    }
+    test "enum can be read by both cecil and reflection" {
+      assertAssemblyDefinitionMatchesAssembly CT.enum T.enum
+    }
+    test "enum2 can be read by both cecil and reflection" {
+      assertAssemblyDefinitionMatchesAssembly CT.enum2 T.enum2
+    }
+    test "enum3 can be read by both cecil and reflection" {
+      assertAssemblyDefinitionMatchesAssembly CT.enum3 T.enum3
+    }
+
+    test "fsharp can be read by both cecil and reflection" {
+      assertAssemblyDefinitionMatchesAssembly CT.fsharp T.fsharp
+    }
+    test "fsharp2 can be read by both cecil and reflection" {
+      assertAssemblyDefinitionMatchesAssembly CT.fsharp2 T.fsharp2
+    }
+    ptest "fsharp can be serialized and deserialized" {
+      assertCanSerializeAndDeserialize CT.fsharp
+    }
+    ptest "fsharp2 can be serialized and deserialized" {
+      assertCanSerializeAndDeserialize CT.fsharp2
+    }
+    ptest "argu can be serialized and deserialized" {
+      assertCanSerializeAndDeserialize CT.arguAssembly
+    }
+    ptest "chiron can be serialized and deserialized"{
+      assertCanSerializeAndDeserialize CT.chironAssembly
+    }
+  ]
+

--- a/tests/SynVer.Tests/DecompileAssemblyTests.fs
+++ b/tests/SynVer.Tests/DecompileAssemblyTests.fs
@@ -39,26 +39,26 @@ let tests =
     }
     
     
-    test "csharp can be read by both cecil and reflection" {
+    ptest "csharp can be read by both cecil and reflection" {
       assertAssemblyDefinitionMatchesAssembly CT.csharp T.csharp
     }
-    test "csharp2 can be read by both cecil and reflection" {
+    ptest "csharp2 can be read by both cecil and reflection" {
       assertAssemblyDefinitionMatchesAssembly CT.csharp2 T.csharp2
     }
-    test "enum can be read by both cecil and reflection" {
+    ptest "enum can be read by both cecil and reflection" {
       assertAssemblyDefinitionMatchesAssembly CT.enum T.enum
     }
-    test "enum2 can be read by both cecil and reflection" {
+    ptest "enum2 can be read by both cecil and reflection" {
       assertAssemblyDefinitionMatchesAssembly CT.enum2 T.enum2
     }
-    test "enum3 can be read by both cecil and reflection" {
+    ptest "enum3 can be read by both cecil and reflection" {
       assertAssemblyDefinitionMatchesAssembly CT.enum3 T.enum3
     }
 
-    test "fsharp can be read by both cecil and reflection" {
+    ptest "fsharp can be read by both cecil and reflection" {
       assertAssemblyDefinitionMatchesAssembly CT.fsharp T.fsharp
     }
-    test "fsharp2 can be read by both cecil and reflection" {
+    ptest "fsharp2 can be read by both cecil and reflection" {
       assertAssemblyDefinitionMatchesAssembly CT.fsharp2 T.fsharp2
     }
     ptest "fsharp can be serialized and deserialized" {

--- a/tests/SynVer.Tests/DecompileNetTypeTests.fs
+++ b/tests/SynVer.Tests/DecompileNetTypeTests.fs
@@ -1,0 +1,35 @@
+module SynVer.DecompileNetTypeTests
+open SynVer
+open Expecto
+open TestHelper
+module CT = CecilTypes
+
+[<Tests>]
+let tests =
+  testList "Net Type of Type definition" [
+
+    test "Tag net type union" {
+      let t = CT.union
+      Expect.equal (Decompile.tagNetType t) NetType.SumType "sumtype union"
+    }
+    test "Tag net type union prime" {
+      let t = CT.unionWithParam
+      Expect.equal (Decompile.tagNetType t) NetType.SumType "sumtype union prime"
+    }
+    test "Tag net type union with names" {
+      let t = CT.unionWithParamNames
+      Expect.equal (Decompile.tagNetType t) NetType.SumType "sumtype with tag"
+    }
+    test "Tag net type enum" {
+      let t = CT.enumType
+      Expect.equal (Decompile.tagNetType t) NetType.Enum "enum type"
+    }
+    test "Tag net type record" {
+      let t = CT.recordType
+      Expect.equal (Decompile.tagNetType t) NetType.RecordType "record type"
+    }
+    test "Tag net type fsharp struct"{
+      let t = CT.fsharpStruct
+      Expect.equal (Decompile.tagNetType t) NetType.Struct "struct type"
+    }
+  ]

--- a/tests/SynVer.Tests/DecompileSurfaceAreaTests.fs
+++ b/tests/SynVer.Tests/DecompileSurfaceAreaTests.fs
@@ -1,25 +1,27 @@
-module SynVer.SurfaceAreaTests
+module SynVer.DecompileSurfaceAreaTests
 open SynVer
 open Expecto
-open TestHelper.Types
+
+open TestHelper
+module CT = CecilTypes
 
 [<Tests>]
 let tests =
-  testList "Surface area" [
+  testList "Surface area of Type Definition" [
     test "Union surface area" {
-      let t = typeof<Union>
-      let area = SurfaceArea.ofType t
+      let t = CT.union
+      let area = SurfaceArea.ofTypeDefinition t
       let typ= area.Type
       let expected =[ UnionCase (typ,"FooBar", [])
                       UnionCase (typ,"Foo",[])
                       UnionCase (typ,"Bar",[])
                     ]
-      Expect.equal area.UnionCases.Value.Cases expected "union cases"
+      Expect.equal expected area.UnionCases.Value.Cases "union cases"
       Expect.isTrue (area.Enum.IsNone) "is none"
     }
     test "Union with params surface area" {
-      let t = typeof<UnionWithParam>
-      let area = SurfaceArea.ofType t
+      let t = CT.unionWithParam
+      let area = SurfaceArea.ofTypeDefinition t
       let typ= area.Type
       let expected = [
                       UnionCase (typ, "Foo",
@@ -32,8 +34,8 @@ let tests =
       Expect.isTrue (area.Enum.IsNone) "is none"
     }
     test "Union with names surface area" {
-      let t = typeof<UnionCaseWithName>
-      let area = SurfaceArea.ofType t
+      let t = CT.unionCaseWithName
+      let area = SurfaceArea.ofTypeDefinition t
       let typ= area.Type
       let expected = [
                       UnionCase (typ, "Foo",
@@ -48,8 +50,8 @@ let tests =
     }
 
     test "Enum surface area" {
-      let t = typeof<EnumType>
-      let area = SurfaceArea.ofType t
+      let t = CT.enumType
+      let area = SurfaceArea.ofTypeDefinition t
       let expected = [("FooBar","0"); ("Foo","1"); ("Bar","2")]
 
       Expect.equal area.Enum.Value expected "enum value"

--- a/tests/SynVer.Tests/DecompileSurfaceAreaTests.fs
+++ b/tests/SynVer.Tests/DecompileSurfaceAreaTests.fs
@@ -25,7 +25,7 @@ let tests =
       let typ= area.Type
       let expected = [
                       UnionCase (typ, "Foo",
-                        [{Type= {FullName="System.Tuple<System.Int32,System.Double>"}; Name=null }])
+                        [{Type= {FullName="System.Tuple`2<System.Int32,System.Double>"}; Name=null }])
                       UnionCase (typ, "Bar",
                         [{Type={FullName="System.Double"}; Name=null}])
                       ]

--- a/tests/SynVer.Tests/DecompileSurfaceAreaTests.fs
+++ b/tests/SynVer.Tests/DecompileSurfaceAreaTests.fs
@@ -25,7 +25,7 @@ let tests =
       let typ= area.Type
       let expected = [
                       UnionCase (typ, "Foo",
-                        [{Type= {FullName="System.Tuple`2<System.Int32,System.Double>"}; Name=null }])
+                        [{Type= {FullName="System.Tuple<System.Int32,System.Double>"}; Name=null }])
                       UnionCase (typ, "Bar",
                         [{Type={FullName="System.Double"}; Name=null}])
                       ]
@@ -55,6 +55,36 @@ let tests =
       let expected = [("FooBar","0"); ("Foo","1"); ("Bar","2")]
 
       Expect.equal area.Enum.Value expected "enum value"
+      Expect.isTrue (area.UnionCases.IsNone) "is none"
+    }
+    test "Class with event surface area" {
+      let t = CT.myClassWithCLIEvent
+      let area = SurfaceArea.ofTypeDefinition t
+      let expected = [Method {Type = {FullName = "SynVer.TestHelper.Types.MyClassWithCLIEvent";};
+                              Instance = InstanceOrStatic.Instance;
+                              Name = "TestEvent";
+                              Parameters = [{Type = {FullName = "System.Object";};
+                                             Name = "arg";}];
+                              Result = {FullName = "System.Void";};};
+                      Constructor
+                        {Type = {FullName = "SynVer.TestHelper.Types.MyClassWithCLIEvent";};
+                         Parameters = [];};
+                      Event
+                        {Type =
+                          {FullName =
+                            "SynVer.TestHelper.Types.MyClassWithCLIEvent";};
+                         Instance = InstanceOrStatic.Instance;
+                         Name = "Event1";
+                         Parameters =
+                          [{Type = {FullName = "System.Object";};
+                            Name = "sender";};
+                           {Type =
+                             {FullName =
+                               "System.Tuple<SynVer.TestHelper.Types.MyClassWithCLIEvent,System.Object>";};
+                            Name = "args";}];
+                         Result = {FullName = "System.Void";};}]
+
+      Expect.equal area.Members expected (sprintf "\n\n\nExpected empty diff \n\n\n%A\n\n\n" (Compare.members area.Members expected))
       Expect.isTrue (area.UnionCases.IsNone) "is none"
     }
   ]

--- a/tests/SynVer.Tests/DecompileTests.fs
+++ b/tests/SynVer.Tests/DecompileTests.fs
@@ -3,7 +3,8 @@ open SynVer
 open Expecto
 
 open TestHelper
-open CecilTestAssemblies
+module CT= CecilTestAssemblies
+module T= TestAssemblies
 
 let assertCanSerializeAndDeserialize assembly
   =
@@ -13,35 +14,64 @@ let assertCanSerializeAndDeserialize assembly
           |> Lson.serialize
           |> Lson.deserialize
     Expect.equal surface deserialized (assembly.ToString())
+let assertAssemblyDefinitionMatchesAssembly assemblyDef assembly 
+  =
+    let surfaceDef = SurfaceArea.ofAssemblyDefinition assemblyDef
+    let surface = SurfaceArea.ofAssembly assembly
+    Expect.equal surfaceDef surface (assemblyDef.ToString())
 [<Tests>]
 let tests =
   testList "Serialization tests (Mono.Cecil)" [    
-    test "csharp" {
-      assertCanSerializeAndDeserialize csharp
+    test "csharp can be serialized and deserialized" {
+      assertCanSerializeAndDeserialize CT.csharp
     }
-    test "csharp2" {
-      assertCanSerializeAndDeserialize csharp2
+    test "csharp2 can be serialized and deserialized" {
+      assertCanSerializeAndDeserialize CT.csharp2
     }
-    test "enum" {
-      assertCanSerializeAndDeserialize enum
+    test "enum can be serialized and deserialized" {
+      assertCanSerializeAndDeserialize CT.enum
     }
-    test "enum2" {
-      assertCanSerializeAndDeserialize enum2
+    test "enum2 can be serialized and deserialized" {
+      assertCanSerializeAndDeserialize CT.enum2
     }
-    test "enum3" {
-      assertCanSerializeAndDeserialize enum3
+    test "enum3 can be serialized and deserialized" {
+      assertCanSerializeAndDeserialize CT.enum3
     }
-    ptest "fsharp" {
-      assertCanSerializeAndDeserialize fsharp
+    
+    
+    test "csharp can be read by both cecil and reflection" {
+      assertAssemblyDefinitionMatchesAssembly CT.csharp T.csharp
     }
-    ptest "fsharp2" {
-      assertCanSerializeAndDeserialize fsharp2
+    test "csharp2 can be read by both cecil and reflection" {
+      assertAssemblyDefinitionMatchesAssembly CT.csharp2 T.csharp2
     }
-    ptest "argu" {
-      assertCanSerializeAndDeserialize arguAssembly
+    test "enum can be read by both cecil and reflection" {
+      assertAssemblyDefinitionMatchesAssembly CT.enum T.enum
     }
-    ptest "chiron"{
-      assertCanSerializeAndDeserialize chironAssembly
+    test "enum2 can be read by both cecil and reflection" {
+      assertAssemblyDefinitionMatchesAssembly CT.enum2 T.enum2
+    }
+    test "enum3 can be read by both cecil and reflection" {
+      assertAssemblyDefinitionMatchesAssembly CT.enum3 T.enum3
+    }
+
+    test "fsharp can be read by both cecil and reflection" {
+      assertAssemblyDefinitionMatchesAssembly CT.fsharp T.fsharp
+    }
+    test "fsharp2 can be read by both cecil and reflection" {
+      assertAssemblyDefinitionMatchesAssembly CT.fsharp2 T.fsharp2
+    }
+    ptest "fsharp can be serialized and deserialized" {
+      assertCanSerializeAndDeserialize CT.fsharp
+    }
+    ptest "fsharp2 can be serialized and deserialized" {
+      assertCanSerializeAndDeserialize CT.fsharp2
+    }
+    ptest "argu can be serialized and deserialized" {
+      assertCanSerializeAndDeserialize CT.arguAssembly
+    }
+    ptest "chiron can be serialized and deserialized"{
+      assertCanSerializeAndDeserialize CT.chironAssembly
     }
   ]
 

--- a/tests/SynVer.Tests/DecompileTests.fs
+++ b/tests/SynVer.Tests/DecompileTests.fs
@@ -21,7 +21,7 @@ let assertAssemblyDefinitionMatchesAssembly assemblyDef assembly
     Expect.equal surfaceDef surface (assemblyDef.ToString())
 [<Tests>]
 let tests =
-  testList "Serialization tests (Mono.Cecil)" [    
+  testList "Read assembly tests (Mono.Cecil)" [    
     test "csharp can be serialized and deserialized" {
       assertCanSerializeAndDeserialize CT.csharp
     }

--- a/tests/SynVer.Tests/DecompileTests.fs
+++ b/tests/SynVer.Tests/DecompileTests.fs
@@ -3,75 +3,8 @@ open SynVer
 open Expecto
 
 open TestHelper
-module CT= CecilTestAssemblies
-module T= TestAssemblies
 
-let assertCanSerializeAndDeserialize assembly
-  =
-    let surface = SurfaceArea.ofAssemblyDefinition assembly
-    let deserialized 
-        = surface
-          |> Lson.serialize
-          |> Lson.deserialize
-    Expect.equal surface deserialized (assembly.ToString())
-let assertAssemblyDefinitionMatchesAssembly assemblyDef assembly 
-  =
-    let surfaceDef = SurfaceArea.ofAssemblyDefinition assemblyDef
-    let surface = SurfaceArea.ofAssembly assembly
-    Expect.equal surfaceDef surface (assemblyDef.ToString())
 [<Tests>]
 let tests =
-  testList "Read assembly tests (Mono.Cecil)" [    
-    test "csharp can be serialized and deserialized" {
-      assertCanSerializeAndDeserialize CT.csharp
-    }
-    test "csharp2 can be serialized and deserialized" {
-      assertCanSerializeAndDeserialize CT.csharp2
-    }
-    test "enum can be serialized and deserialized" {
-      assertCanSerializeAndDeserialize CT.enum
-    }
-    test "enum2 can be serialized and deserialized" {
-      assertCanSerializeAndDeserialize CT.enum2
-    }
-    test "enum3 can be serialized and deserialized" {
-      assertCanSerializeAndDeserialize CT.enum3
-    }
-    
-    
-    test "csharp can be read by both cecil and reflection" {
-      assertAssemblyDefinitionMatchesAssembly CT.csharp T.csharp
-    }
-    test "csharp2 can be read by both cecil and reflection" {
-      assertAssemblyDefinitionMatchesAssembly CT.csharp2 T.csharp2
-    }
-    test "enum can be read by both cecil and reflection" {
-      assertAssemblyDefinitionMatchesAssembly CT.enum T.enum
-    }
-    test "enum2 can be read by both cecil and reflection" {
-      assertAssemblyDefinitionMatchesAssembly CT.enum2 T.enum2
-    }
-    test "enum3 can be read by both cecil and reflection" {
-      assertAssemblyDefinitionMatchesAssembly CT.enum3 T.enum3
-    }
-
-    test "fsharp can be read by both cecil and reflection" {
-      assertAssemblyDefinitionMatchesAssembly CT.fsharp T.fsharp
-    }
-    test "fsharp2 can be read by both cecil and reflection" {
-      assertAssemblyDefinitionMatchesAssembly CT.fsharp2 T.fsharp2
-    }
-    ptest "fsharp can be serialized and deserialized" {
-      assertCanSerializeAndDeserialize CT.fsharp
-    }
-    ptest "fsharp2 can be serialized and deserialized" {
-      assertCanSerializeAndDeserialize CT.fsharp2
-    }
-    ptest "argu can be serialized and deserialized" {
-      assertCanSerializeAndDeserialize CT.arguAssembly
-    }
-    ptest "chiron can be serialized and deserialized"{
-      assertCanSerializeAndDeserialize CT.chironAssembly
-    }
-  ]
+  testList "Decompile tests" []
 

--- a/tests/SynVer.Tests/DecompileTests.fs
+++ b/tests/SynVer.Tests/DecompileTests.fs
@@ -1,12 +1,13 @@
-module SynVer.SerializationTests
+module SynVer.DecompileTests
 open SynVer
 open Expecto
+
 open TestHelper
-open TestAssemblies
+open CecilTestAssemblies
 
 let assertCanSerializeAndDeserialize assembly
   =
-    let surface = SurfaceArea.ofAssembly assembly
+    let surface = SurfaceArea.ofAssemblyDefinition assembly
     let deserialized 
         = surface
           |> Lson.serialize
@@ -14,7 +15,7 @@ let assertCanSerializeAndDeserialize assembly
     Expect.equal surface deserialized (assembly.ToString())
 [<Tests>]
 let tests =
-  testList "Serialization tests" [    
+  testList "Serialization tests (Mono.Cecil)" [    
     test "csharp" {
       assertCanSerializeAndDeserialize csharp
     }

--- a/tests/SynVer.Tests/NetTypeTests.fs
+++ b/tests/SynVer.Tests/NetTypeTests.fs
@@ -8,45 +8,45 @@ let tests =
 
     test "Tag net type NetType" {
       let t = typeof<Version>
-      Expect.equal NetType.SumType (Reflect.tagNetType t) "sum type t"
+      Expect.equal (Reflect.tagNetType t) NetType.SumType "sum type t"
       let n = Version.Major
       let nt = n.GetType()
-      Expect.equal NetType.SumType (Reflect.tagNetType nt) "sum type nt"
+      Expect.equal (Reflect.tagNetType nt) NetType.SumType "sum type nt"
     }
     test "Tag net type union" {
       let t = typeof<Union>
-      Expect.equal NetType.SumType (Reflect.tagNetType t) "sumtype union"
+      Expect.equal (Reflect.tagNetType t) NetType.SumType "sumtype union"
     }
     test "Tag net type union prime" {
       let t = typeof<UnionWithParam>
-      Expect.equal NetType.SumType (Reflect.tagNetType t) "sumtype union prime"
+      Expect.equal (Reflect.tagNetType t) NetType.SumType "sumtype union prime"
       let foo=UnionWithParam.Foo (1,0.1)
       let fooT =foo.GetType()
       Expect.isTrue (Reflect.isSumType fooT) "fooT"
     }
     test "Tag net type union with names" {
       let t = typeof<UnionWithParamNames>
-      Expect.equal NetType.SumType (Reflect.tagNetType t) "sumtype with tag"
+      Expect.equal (Reflect.tagNetType t) NetType.SumType "sumtype with tag"
       let foo = UnionWithParamNames.Foo(num=1,diff=0.1)
       let fooT = foo.GetType()
       Expect.isTrue (Reflect.isSumType fooT) "is sumtype"
     }
     test "Tag net type enum" {
       let t = typeof<EnumType>
-      Expect.equal NetType.Enum (Reflect.tagNetType t) "enum type"
+      Expect.equal (Reflect.tagNetType t) NetType.Enum "enum type"
     }
     test "Tag net type record" {
       let t = typeof<RecordType>
-      Expect.equal NetType.RecordType (Reflect.tagNetType t) "record type"
+      Expect.equal (Reflect.tagNetType t) NetType.RecordType "record type"
     }
     test "Tag net type csharp struct"{
-      Expect.equal NetType.Struct (Reflect.tagNetType CSharpStructType) "struct type"
+      Expect.equal (Reflect.tagNetType CSharpStructType) NetType.Struct "struct type"
     }
     test "Tag net type fsharp struct"{
       let t = typeof<FsharpStruct>
-      Expect.equal NetType.Struct (Reflect.tagNetType t) "struct type"
+      Expect.equal (Reflect.tagNetType t) NetType.Struct "struct type"
     }
     test "Tag net type module"{
-      Expect.equal NetType.Module (Reflect.tagNetType ModuleT) "module"
+      Expect.equal (Reflect.tagNetType ModuleT) NetType.Module "module"
     }
   ]

--- a/tests/SynVer.Tests/SurfaceAreaTests.fs
+++ b/tests/SynVer.Tests/SurfaceAreaTests.fs
@@ -55,4 +55,34 @@ let tests =
       Expect.equal area.Enum.Value expected "enum value"
       Expect.isTrue (area.UnionCases.IsNone) "is none"
     }
+    test "Class with event surface area" {
+      let t = typeof<MyClassWithCLIEvent>
+      let area = SurfaceArea.ofType t
+      let expected = [Method {Type = {FullName = "SynVer.TestHelper.Types.MyClassWithCLIEvent";};
+                              Instance = InstanceOrStatic.Instance;
+                              Name = "TestEvent";
+                              Parameters = [{Type = {FullName = "System.Object";};
+                                             Name = "arg";}];
+                              Result = {FullName = "System.Void";};};
+                      Constructor
+                        {Type = {FullName = "SynVer.TestHelper.Types.MyClassWithCLIEvent";};
+                         Parameters = [];};
+                      Event
+                        {Type =
+                          {FullName =
+                            "SynVer.TestHelper.Types.MyClassWithCLIEvent";};
+                         Instance = InstanceOrStatic.Instance;
+                         Name = "Event1";
+                         Parameters =
+                          [{Type = {FullName = "System.Object";};
+                            Name = "sender";};
+                           {Type =
+                             {FullName =
+                               "System.Tuple<SynVer.TestHelper.Types.MyClassWithCLIEvent,System.Object>";};
+                            Name = "args";}];
+                         Result = {FullName = "System.Void";};}]
+
+      Expect.equal area.Members expected (sprintf "\n\n\nExpected empty diff \n\n\n%A\n\n\n" (Compare.members area.Members expected))
+      Expect.isTrue (area.UnionCases.IsNone) "is none"
+    }
   ]

--- a/tests/SynVer.Tests/SynVer.Tests.fsproj
+++ b/tests/SynVer.Tests/SynVer.Tests.fsproj
@@ -17,6 +17,8 @@
     <Compile Include="NetTypeTests.fs" />
     <Compile Include="SerializationTests.fs" />
     <Compile Include="DecompileTests.fs" />
+    <Compile Include="DecompileSurfaceAreaTests.fs" />
+    <Compile Include="DecompileNetTypeTests.fs" />
     <Compile Include="Program.fs" />
   </ItemGroup>
   <ItemGroup>

--- a/tests/SynVer.Tests/SynVer.Tests.fsproj
+++ b/tests/SynVer.Tests/SynVer.Tests.fsproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFrameworks>net461;netcoreapp2.0</TargetFrameworks>
@@ -16,6 +16,7 @@
     <Compile Include="SurfaceAreaTests.fs" />
     <Compile Include="NetTypeTests.fs" />
     <Compile Include="SerializationTests.fs" />
+    <Compile Include="DecompileTests.fs" />
     <Compile Include="Program.fs" />
   </ItemGroup>
   <ItemGroup>

--- a/tests/SynVer.Tests/SynVer.Tests.fsproj
+++ b/tests/SynVer.Tests/SynVer.Tests.fsproj
@@ -17,6 +17,7 @@
     <Compile Include="NetTypeTests.fs" />
     <Compile Include="SerializationTests.fs" />
     <Compile Include="DecompileTests.fs" />
+    <Compile Include="DecompileAssemblyTests.fs" />
     <Compile Include="DecompileSurfaceAreaTests.fs" />
     <Compile Include="DecompileNetTypeTests.fs" />
     <Compile Include="Program.fs" />

--- a/tests/SynVer.Tests/TestHelper.fs
+++ b/tests/SynVer.Tests/TestHelper.fs
@@ -67,7 +67,12 @@ module Types=
   type RecordType = { Foo:int}
   type UnionWithParamNames = Foo of num: int * diff:float | Bar of diff:float
   let CSharpStructType = TestAssemblies.csharp.ExportedTypes |> Seq.find (fun t-> t.Name= "Struct")
+  type MyClassWithCLIEvent() =
+    let event1 = new Event<_>()
 
+    [<CLIEvent>]
+    member this.Event1 = event1.Publish
+    member this.TestEvent(arg) = event1.Trigger(this, arg)
   type FsharpStruct =
    struct
       val x: float
@@ -86,7 +91,7 @@ module CecilTypes=
   let recordType = AssemblyDefinition.getType typeof< Types.RecordType> assembly
   let unionWithParamNames = AssemblyDefinition.getType typeof< Types.UnionWithParamNames> assembly
   let fsharpStruct = AssemblyDefinition.getType typeof< Types.FsharpStruct> assembly
-
+  let myClassWithCLIEvent = AssemblyDefinition.getType typeof< Types.MyClassWithCLIEvent> assembly
 module Assemblies=
   [<CompiledName("Bump")>]
   let bump verNr released modified =

--- a/tests/SynVer.Tests/TestHelper.fs
+++ b/tests/SynVer.Tests/TestHelper.fs
@@ -93,7 +93,7 @@ module Types=
 module CecilTypes=
   open Mono.Cecil
   let assembly =
-    AssemblyDefinition.ReadAssembly (typeof< Types.UnionCaseWithName>).Assembly.Location
+    AssemblyDefinition.readAssembly (typeof< Types.UnionCaseWithName>).Assembly.Location
   let unionCaseWithName = AssemblyDefinition.getType typeof< Types.UnionCaseWithName> assembly 
   let union = AssemblyDefinition.getType typeof< Types.Union> assembly
   let unionWithParam = AssemblyDefinition.getType typeof< Types.UnionWithParam> assembly

--- a/tests/SynVer.Tests/TestHelper.fs
+++ b/tests/SynVer.Tests/TestHelper.fs
@@ -19,22 +19,7 @@ module AssemblyDefinition=
   open Mono.Cecil
   open System
 
-  let readAssembly (path:string)=
-    let a= { new DefaultAssemblyResolver()
-             with
-               override this.Resolve(name:AssemblyNameReference)=
-                 try
-                   base.Resolve(name)
-                 with _->
-                   // hack to avoid assembly load failure on Windows
-                   if name.Name.Equals("FSharp.Core", StringComparison.OrdinalIgnoreCase) then 
-                     AssemblyDefinition.ReadAssembly (typeof< FSharp.Core.FSharpTypeFunc>).Assembly.Location
-                   else
-                     null
-           }
-    let r = ReaderParameters()
-    r.AssemblyResolver <- a
-    AssemblyDefinition.ReadAssembly(path,r)
+  let readAssembly (path:string) = Decompile.readAssembly path
   let getNestedTypes (t:TypeDefinition) =t.NestedTypes
   let rec tryFindNestedType  (t:System.Type) (td:TypeDefinition) =
     if td.FullName = t.FullName.Replace('+','/') then

--- a/tests/SynVer.Tests/TestHelper.fs
+++ b/tests/SynVer.Tests/TestHelper.fs
@@ -12,20 +12,35 @@ let testPath= Path.GetDirectoryName asm.Location
 let exampleProjectsPath = Path.GetFullPath( testPath </> ".."</>".."</>".."</> ".."</> "ExampleProjects")
 let packagesPath = Path.GetFullPath( testPath </> ".."</>".."</>".."</>".."</> ".."</> "packages")
 let exampleProjectsLibPath = exampleProjectsPath </> "lib"
-// since all the dll-s have unique names, they can be loaded at the same time
-let csharp = exampleProjectsLibPath </> "Csharp.dll" |> Assembly.LoadFile
-let csharp2 = exampleProjectsLibPath </> "Csharp2.dll" |> Assembly.LoadFile
-let csharpWithAttribute = exampleProjectsLibPath </> "CsharpWithAttribute.dll" |> Assembly.LoadFile
-let enum = exampleProjectsLibPath </> "Enum.dll" |> Assembly.LoadFile
-let enum2 = exampleProjectsLibPath </> "Enum2.dll" |> Assembly.LoadFile
 let enum2txt = exampleProjectsPath </> "src" </> "Enum2.txt" |> File.ReadAllLines |>nlJoin |> wTrim
-let enum3 = exampleProjectsLibPath </> "Enum3.dll" |> Assembly.LoadFile
 let enum3txt = exampleProjectsPath </> "src" </> "Enum3.txt" |> File.ReadAllLines |>nlJoin |> wTrim
-let fsharp = exampleProjectsLibPath </> "Fsharp.dll" |> Assembly.LoadFile
-let fsharp2 = exampleProjectsLibPath </> "Fsharp2.dll" |> Assembly.LoadFile
 let fsharp2txt = exampleProjectsPath </> "src" </> "Fsharp2.txt" |> File.ReadAllLines |>nlJoin |> wTrim
-let arguAssembly= packagesPath </>"Argu"</>"lib"</> "net45" </>"Argu.dll" |> Assembly.LoadFile
-let chironAssembly= packagesPath </>"Chiron"</>"lib"</> "net40" </>"Chiron.dll" |> Assembly.LoadFile
+
+module TestAssemblies=
+    // since all the dll-s have unique names, they can be loaded at the same time
+    let csharp = exampleProjectsLibPath </> "Csharp.dll" |> Assembly.LoadFile
+    let csharp2 = exampleProjectsLibPath </> "Csharp2.dll" |> Assembly.LoadFile
+    let csharpWithAttribute = exampleProjectsLibPath </> "CsharpWithAttribute.dll" |> Assembly.LoadFile
+    let enum = exampleProjectsLibPath </> "Enum.dll" |> Assembly.LoadFile
+    let enum2 = exampleProjectsLibPath </> "Enum2.dll" |> Assembly.LoadFile
+    let enum3 = exampleProjectsLibPath </> "Enum3.dll" |> Assembly.LoadFile
+    let fsharp = exampleProjectsLibPath </> "Fsharp.dll" |> Assembly.LoadFile
+    let fsharp2 = exampleProjectsLibPath </> "Fsharp2.dll" |> Assembly.LoadFile
+    let arguAssembly= packagesPath </>"Argu"</>"lib"</> "net45" </>"Argu.dll" |> Assembly.LoadFile
+    let chironAssembly= packagesPath </>"Chiron"</>"lib"</> "net40" </>"Chiron.dll" |> Assembly.LoadFile
+module CecilTestAssemblies=
+    open Mono.Cecil
+    // since all the dll-s have unique names, they can be loaded at the same time
+    let csharp = exampleProjectsLibPath </> "Csharp.dll" |> AssemblyDefinition.ReadAssembly
+    let csharp2 = exampleProjectsLibPath </> "Csharp2.dll" |> AssemblyDefinition.ReadAssembly
+    let csharpWithAttribute = exampleProjectsLibPath </> "CsharpWithAttribute.dll" |> AssemblyDefinition.ReadAssembly
+    let enum = exampleProjectsLibPath </> "Enum.dll" |> AssemblyDefinition.ReadAssembly
+    let enum2 = exampleProjectsLibPath </> "Enum2.dll" |> AssemblyDefinition.ReadAssembly
+    let enum3 = exampleProjectsLibPath </> "Enum3.dll" |> AssemblyDefinition.ReadAssembly
+    let fsharp = exampleProjectsLibPath </> "Fsharp.dll" |> AssemblyDefinition.ReadAssembly
+    let fsharp2 = exampleProjectsLibPath </> "Fsharp2.dll" |> AssemblyDefinition.ReadAssembly
+    let arguAssembly= packagesPath </>"Argu"</>"lib"</> "net45" </>"Argu.dll" |> AssemblyDefinition.ReadAssembly
+    let chironAssembly= packagesPath </>"Chiron"</>"lib"</> "net40" </>"Chiron.dll" |> AssemblyDefinition.ReadAssembly
 
 module Types=
   type UnionCaseWithName = Foo of num: int * diff:float | Bar of diff:float
@@ -35,14 +50,14 @@ module Types=
   type EnumType = FooBar=0 | Foo=1 | Bar =2
   type RecordType = { Foo:int}
   type UnionWithParamNames = Foo of num: int * diff:float | Bar of diff:float
-  let CSharpStructType = csharp.ExportedTypes |> Seq.find (fun t-> t.Name= "Struct")
+  let CSharpStructType = TestAssemblies.csharp.ExportedTypes |> Seq.find (fun t-> t.Name= "Struct")
 
   type FsharpStruct =
    struct
       val x: float
    end
   
-  let ModuleT= fsharp.ExportedTypes |> Seq.find (fun t-> t.Name="Module")
+  let ModuleT= TestAssemblies.fsharp.ExportedTypes |> Seq.find (fun t-> t.Name="Module")
 
 module Assemblies=
   [<CompiledName("Bump")>]

--- a/tests/SynVer.Tests/Tests.fs
+++ b/tests/SynVer.Tests/Tests.fs
@@ -21,7 +21,7 @@ let tests =
                 |> wTrim
       Expect.equal enum2txt diff "enum 2 diff"
       let bump = Assemblies.bump "1.0.0" enum enum2
-      Expect.equal  ("2.0.0", Major) bump "Major change"
+      Expect.equal bump ("2.0.0", Major) "Major change"
     }
 
     test "enum vs enum3" {
@@ -30,12 +30,12 @@ let tests =
                 |> wTrim
       Expect.equal enum3txt diff "enum 3 diff"
       let bump = Assemblies.bump "1.0.0" enum enum3
-      Expect.equal ("1.1.0", Minor) bump "Minor change"
+      Expect.equal bump ("1.1.0", Minor) "Minor change"
     }
     test "fsharp vs fsharp2" {
       let diff = Assemblies.diff fsharp fsharp2
                 |> nlJoin
                 |> wTrim
-      Expect.equal fsharp2txt diff "fsharp 2 diff"
+      Expect.equal diff fsharp2txt "fsharp 2 diff"
     }
   ]

--- a/tests/SynVer.Tests/Tests.fs
+++ b/tests/SynVer.Tests/Tests.fs
@@ -1,8 +1,9 @@
 module SynVer.Tests
 open SynVer
 open Expecto
-
 open TestHelper
+open TestAssemblies
+
 [<Tests>]
 let tests =
   testList "assembly diff" [


### PR DESCRIPTION
This fixes #21 
This will also fix #18 since it then should be possible to diff assemblies without loading them using reflection.