### PR TITLE
#35 make build work cross-platform

### DIFF
--- a/build.fsx
+++ b/build.fsx
@@ -147,7 +147,6 @@ module create =
         //fsharpc --target:library --out:"./lib/"${name%.*}".dll" $f "./src/AssemblyInfo.fs"
 
     let csharpProjectFromFile fileName name =
-        Console.WriteLine(sdk.path)
         let cscLocation (sdk: SDKs.Sdk) =
           Path.Combine(sdk.path, sdk.version, "Roslyn", "bincore", "csc.dll")
 


### PR DESCRIPTION
A fix for https://github.com/fsprojects/SyntacticVersioning/issues/35

I'm not sure if this will actually work on a non-Windows OS, but it does work on my Windows machine.  Here's what I changed:

- We can't expect 'which' to exist or be in the path on Windows, so if the build is running on Windows, it will use 'where', instead, which will fit our needs if we don't have access to 'which'.
- There were some errors that could happen if there were whitespaces in the path names of the .NET SDK that the build searches for, so I fixed as many of those errors as I was able to find.